### PR TITLE
chore: remove unused shallow import from theme store

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -118,10 +118,11 @@
 ---
 
 ## Agent 10 — Database/Functionality Checks
-**Scope:** Ensure functional logic and DB integration still work after UI changes.  
-**Tasks:**  
-- Verify forms still submit correctly.  
-- Confirm API/data fetching unaffected.  
-- Log any issues needing backend fixes.  
-**Status:** TODO  
-**Log:**  
+**Scope:** Ensure functional logic and DB integration still work after UI changes.
+**Tasks:**
+- Verify forms still submit correctly.
+- Confirm API/data fetching unaffected.
+- Log any issues needing backend fixes.
+**Status:** TODO
+**Log:**
+- Reviewed theme store for unused imports and removed the unused `shallow` import to satisfy TypeScript checks. Awaiting broader functionality verification.

--- a/src/stores/themeStore.ts
+++ b/src/stores/themeStore.ts
@@ -1,6 +1,5 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
-import { shallow } from 'zustand/shallow';
 import { TenantSettings } from '../types';
 
 export type ThemeMode = 'light' | 'dark' | 'auto';


### PR DESCRIPTION
## Summary
- remove the unused `shallow` import from the theme store to satisfy the TypeScript compiler
- document the change in the Agent 10 log per coordination guidelines

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cf7d7a2778832697c7dba25aca8722