### PR TITLE
feat(forms): add shared form component styles

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -106,14 +106,15 @@
 ---
 
 ## Agent 9 — Forms & Inputs
-**Scope:** Input fields, contact forms, search bars.  
-**Tasks:**  
-- Style inputs and textareas.  
-- Apply palette + typography.  
-- Add focus states and validation feedback.  
-- Document changes.  
-**Status:** TODO  
-**Log:**  
+**Scope:** Input fields, contact forms, search bars.
+**Tasks:**
+- Style inputs and textareas.
+- Apply palette + typography.
+- Add focus states and validation feedback.
+- Document changes.
+**Status:** DONE
+**Log:**
+- Added `.form-field`, `.form-label`, `.form-input`, `.form-helper`, and `.form-range` utilities in `src/index.css` to standardize spacing, focus states, validation colors, and range styling for both light and dark themes. Linting via `npm run lint` exposed existing TypeScript/ESLint errors in unrelated components (`POS.tsx`, `Portal.tsx`, `PaperShader.tsx`, `StatusIndicator.tsx`, `themeStore.ts`); no changes applied to those files to maintain scope.
 
 ---
 

--- a/src/index.css
+++ b/src/index.css
@@ -93,4 +93,123 @@
   [data-paper-cards='true'] .paper-card::before {
     opacity: var(--paper-card-opacity);
   }
+
+  .form-field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    width: 100%;
+  }
+
+  .form-label {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+    font-weight: 600;
+    font-size: 0.95rem;
+    color: rgb(var(--color-ink));
+    letter-spacing: -0.01em;
+  }
+
+  .form-input {
+    width: 100%;
+    padding: 0.75rem 1rem;
+    border-radius: var(--radius-md);
+    border: 1px solid rgba(var(--color-line) / 0.9);
+    background-color: rgb(var(--color-surface-100));
+    color: rgb(var(--color-ink));
+    transition: border-color 0.2s ease, box-shadow 0.2s ease,
+      background-color 0.2s ease, color 0.2s ease;
+  }
+
+  .form-input:hover {
+    border-color: rgba(var(--color-primary-500) / 0.4);
+  }
+
+  .form-input::placeholder {
+    color: rgba(var(--color-muted) / 0.7);
+  }
+
+  .form-input:focus-visible {
+    outline: none;
+    border-color: rgb(var(--color-primary-500));
+    background-color: rgb(var(--color-surface-200));
+    box-shadow: 0 0 0 4px rgba(var(--color-primary-500) / 0.14);
+  }
+
+  .form-input:disabled {
+    opacity: 0.65;
+    cursor: not-allowed;
+  }
+
+  .form-input[aria-invalid='true'] {
+    border-color: rgb(var(--color-danger));
+    box-shadow: 0 0 0 4px rgba(var(--color-danger) / 0.18);
+  }
+
+  .form-helper {
+    font-size: 0.875rem;
+    line-height: 1.4;
+    color: rgba(var(--color-muted) / 0.9);
+  }
+
+  .form-helper[data-state='error'] {
+    color: rgb(var(--color-danger));
+  }
+
+  .form-helper[data-state='success'] {
+    color: rgb(var(--color-success));
+  }
+
+  .form-range {
+    width: 100%;
+    display: block;
+    accent-color: rgb(var(--color-primary-500));
+    background: transparent;
+  }
+
+  .form-range:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 4px rgba(var(--color-primary-500) / 0.14);
+    border-radius: var(--radius-sm);
+  }
+
+  [data-theme='dark'] .form-label {
+    color: rgb(var(--color-ink));
+  }
+
+  [data-theme='dark'] .form-input {
+    background-color: rgb(var(--color-surface-200));
+    border-color: rgba(var(--color-line) / 0.6);
+    color: rgb(var(--color-ink));
+  }
+
+  [data-theme='dark'] .form-input:hover {
+    border-color: rgba(var(--color-primary-500) / 0.5);
+  }
+
+  [data-theme='dark'] .form-input::placeholder {
+    color: rgba(var(--color-ink) / 0.6);
+  }
+
+  [data-theme='dark'] .form-input:focus-visible {
+    background-color: rgb(var(--color-surface-100));
+    box-shadow: 0 0 0 4px rgba(var(--color-primary-500) / 0.22);
+  }
+
+  [data-theme='dark'] .form-helper {
+    color: rgba(var(--color-ink) / 0.7);
+  }
+
+  [data-theme='dark'] .form-helper[data-state='error'] {
+    color: rgb(var(--color-danger));
+  }
+
+  [data-theme='dark'] .form-helper[data-state='success'] {
+    color: rgb(var(--color-success));
+  }
+
+  [data-theme='dark'] .form-range {
+    accent-color: rgb(var(--color-primary-500));
+  }
 }


### PR DESCRIPTION
## Summary
- add reusable form utility classes under the Tailwind components layer with hover, focus, and validation states
- provide dark theme overrides to maintain palette alignment across inputs and helper text
- record the new utilities and lint findings in Agent 9's task log

## Testing
- npm run lint *(fails: pre-existing eslint errors in POS.tsx, Portal.tsx, PaperShader.tsx, StatusIndicator.tsx, themeStore.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68d003d36de48326b339a0b251f1a7c7