### PR TITLE
Refactor login and POS CTAs to share MotionButton

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -100,9 +100,9 @@
 - Apply palette colors correctly.  
 - Ensure accessibility contrast ratios.  
 - Document changes.  
-**Status:** TODO  
+**Status:** DONE  
 **Log:**  
-
+- Replaced Login and POS submit actions with MotionButton using refreshed primary variant while preserving animations; npm run lint still reports pre-existing repository issues outside button scope.  
 ---
 
 ## Agent 9 — Forms & Inputs

--- a/src/components/apps/POS.tsx
+++ b/src/components/apps/POS.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { motion } from 'framer-motion';
+import { Button } from '@mas/ui';
 import { gsap } from 'gsap';
 import { Search, Plus, Minus, Trash2, User, CreditCard, Clock } from 'lucide-react';
 import { MotionWrapper, AnimatedList } from '../ui/MotionWrapper';
@@ -8,6 +9,8 @@ import { useOfflineStore } from '../../stores/offlineStore';
 import { useAuthStore } from '../../stores/authStore';
 import { Product, Category } from '../../types';
 import { mockProducts, mockCategories } from '../../data/mockData';
+
+const MotionButton = motion(Button);
 
 export const POS: React.FC = () => {
   const [searchTerm, setSearchTerm] = useState('');
@@ -207,16 +210,18 @@ export const POS: React.FC = () => {
               </div>
             </div>
             
-            <motion.button
+            <MotionButton
               whileHover={{ scale: 1.02 }}
               whileTap={{ scale: 0.98 }}
               onClick={handleCheckout}
               disabled={items.length === 0}
-              className="w-full bg-primary-500 text-white py-3 rounded-lg font-medium disabled:opacity-50 disabled:cursor-not-allowed hover:bg-primary-600 transition-colors flex items-center justify-center gap-2"
+              variant="primary"
+              size="lg"
+              className="w-full"
             >
               <CreditCard size={18} />
               Process Payment
-            </motion.button>
+            </MotionButton>
           </div>
         </div>
 

--- a/src/components/auth/Login.tsx
+++ b/src/components/auth/Login.tsx
@@ -1,10 +1,13 @@
 import React, { useState } from 'react';
 import { motion } from 'framer-motion';
+import { Button } from '@mas/ui';
 import { LogIn, Eye, EyeOff } from 'lucide-react';
 import { useAuthStore } from '../../stores/authStore';
 import { useNavigate } from 'react-router-dom';
 import { mockUser, mockStore, mockTenant } from '../../data/mockData';
 import { PaperShader } from '../ui/PaperShader';
+
+const MotionButton = motion(Button);
 
 export const Login: React.FC = () => {
   const [email, setEmail] = useState('manager@bellavista.com');
@@ -92,12 +95,14 @@ export const Login: React.FC = () => {
               </div>
             </div>
 
-            <motion.button
+            <MotionButton
               type="submit"
               disabled={isLoading}
               whileHover={{ scale: 1.01 }}
               whileTap={{ scale: 0.99 }}
-              className="w-full bg-primary-500 text-white py-3 rounded-lg font-medium disabled:opacity-50 disabled:cursor-not-allowed hover:bg-primary-600 transition-colors flex items-center justify-center gap-2"
+              variant="primary"
+              size="lg"
+              className="w-full"
             >
               {isLoading ? (
                 <div className="w-5 h-5 border-2 border-white/30 border-t-white rounded-full animate-spin" />
@@ -107,7 +112,7 @@ export const Login: React.FC = () => {
                   Sign In
                 </>
               )}
-            </motion.button>
+            </MotionButton>
           </form>
 
           {/* Demo Credentials */}


### PR DESCRIPTION
## Summary
- swap the Login and POS motion.button implementations for motion(Button) wrappers tied to the refreshed primary variant
- keep existing hover/tap animations while standardizing styling through the shared Button component
- record the Agent 8 update in agents.md

## Testing
- npm run lint *(fails: existing lint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d003d1e25c832690069a37c30b16cf