### PR TITLE
feat(button): align variants with MAS palette

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -94,14 +94,22 @@
 ---
 
 ## Agent 8 — Buttons & CTAs
-**Scope:** Button styles across site.  
-**Tasks:**  
-- Standardize button size, radius, and hover states.  
-- Apply palette colors correctly.  
-- Ensure accessibility contrast ratios.  
-- Document changes.  
-**Status:** TODO  
-**Log:**  
+**Scope:** Button styles across site.
+**Tasks:**
+- Standardize button size, radius, and hover states.
+- Apply palette colors correctly.
+- Ensure accessibility contrast ratios.
+- Document changes.
+**Status:** DONE
+**Log:**
+- Updated `src/packages/ui/button.tsx` to apply the MAS palette, add a `cta` variant, and unify transitions/focus rings for consistency.
+- Lint run blocked by pre-existing issues in other components (POS, Portal, PaperShader, StatusIndicator, themeStore); no changes applied to stay within scope.
+- Variant matrix:
+  - Primary — default `bg-[#EE766D] text-[#24242E]` · hover `bg-[#e55e54]` · focus offset `#D6D6D6` · disabled tone reductions.
+  - Secondary — default `bg-[#D6D6D6] text-[#24242E]` · hover `bg-[#c6c6c6]` · focus offset `#D6D6D6` · softened disabled palette.
+  - Outline — default `border/text #24242E` on transparent · hover fills `#24242E` with `#D6D6D6` text · focus offset `#D6D6D6` · muted disabled border/text.
+  - Ghost — default text `#24242E` · hover surface `#D6D6D6`/70 · focus offset `#D6D6D6` · low-emphasis disabled text.
+  - CTA — default `bg-[#24242E] text-[#D6D6D6]` with shadow · hover swaps to `bg-[#EE766D] text-[#24242E]` · focus offset `#24242E` · dimmed disabled state.
 
 ---
 

--- a/src/packages/ui/button.tsx
+++ b/src/packages/ui/button.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { cn } from '@mas/utils';
 
-type ButtonVariant = 'primary' | 'secondary' | 'outline' | 'ghost';
+type ButtonVariant = 'primary' | 'secondary' | 'outline' | 'ghost' | 'cta';
 type ButtonSize = 'sm' | 'md' | 'lg' | 'icon';
 
 export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
@@ -11,13 +11,15 @@ export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElemen
 
 const variantClasses: Record<ButtonVariant, string> = {
   primary:
-    'bg-primary-500 text-white shadow-card hover:bg-primary-600 focus-visible:ring-2 focus-visible:ring-primary-500/40 disabled:bg-primary-500/50 disabled:text-white/70',
+    'bg-[#EE766D] text-[#24242E] shadow-card hover:bg-[#e55e54] focus-visible:ring-offset-[#D6D6D6] disabled:bg-[#EE766D]/60 disabled:text-[#24242E]/70',
   secondary:
-    'bg-surface-100 text-ink hover:bg-surface-200 border border-line focus-visible:ring-2 focus-visible:ring-primary-500/30 disabled:text-muted disabled:bg-surface-200/60',
+    'bg-[#D6D6D6] text-[#24242E] hover:bg-[#c6c6c6] focus-visible:ring-offset-[#D6D6D6] disabled:bg-[#D6D6D6]/70 disabled:text-[#24242E]/50',
   outline:
-    'border border-line text-ink hover:border-primary-200 hover:text-primary-600 focus-visible:ring-2 focus-visible:ring-primary-500/30 disabled:text-muted',
+    'border border-[#24242E] text-[#24242E] hover:bg-[#24242E] hover:text-[#D6D6D6] focus-visible:ring-offset-[#D6D6D6] disabled:border-[#24242E]/40 disabled:text-[#24242E]/40',
   ghost:
-    'text-muted hover:text-ink hover:bg-surface-200 focus-visible:ring-2 focus-visible:ring-primary-500/20 disabled:text-muted',
+    'text-[#24242E] hover:bg-[#D6D6D6]/70 focus-visible:ring-offset-[#D6D6D6] disabled:text-[#24242E]/40',
+  cta:
+    'bg-[#24242E] text-[#D6D6D6] shadow-card hover:bg-[#EE766D] hover:text-[#24242E] focus-visible:ring-offset-[#24242E] disabled:bg-[#24242E]/60 disabled:text-[#D6D6D6]/60',
 };
 
 const sizeClasses: Record<ButtonSize, string> = {
@@ -33,7 +35,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       ref={ref}
       type={type}
       className={cn(
-        'inline-flex items-center justify-center gap-2 font-medium rounded-lg transition-colors duration-150 focus:outline-none disabled:cursor-not-allowed',
+        'inline-flex items-center justify-center gap-2 font-medium rounded-lg transition-colors duration-200 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#EE766D] focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:pointer-events-none disabled:opacity-60',
         variantClasses[variant],
         sizeClasses[size],
         className


### PR DESCRIPTION
## Summary
- update button variants to use the MAS color palette and add a dedicated `cta` style
- standardize button focus rings and transitions across variants
- document the refreshed variant matrix and testing outcome for Agent 8

## Testing
- npm run lint *(fails: pre-existing lint violations in POS.tsx, Portal.tsx, PaperShader.tsx, StatusIndicator.tsx, themeStore.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68d003d151648326a1044835ce5ebf11