### PR TITLE
Add MAS footer component

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -16,8 +16,8 @@
 - Fix misaligned sections, spacing, and grid inconsistencies.  
 - Improve responsiveness (mobile/tablet/desktop).  
 - Keep existing functionality untouched.  
-**Status:** TODO  
-**Log:**  
+**Status:** TODO
+**Log:**
 
 ---
 
@@ -28,20 +28,20 @@
 - Replace off-palette values with correct ones.  
 - Ensure Tailwind config and global tokens are updated.  
 - Verify consistency across all components.  
-**Status:** TODO  
-**Log:**  
+**Status:** TODO
+**Log:**
 
 ---
 
 ## Agent 3 — Typography
-**Scope:** Fonts, sizes, weights, and readability.  
-**Tasks:**  
-- Analyze current font stack.  
-- Apply consistent font sizes for headings, body, buttons.  
-- Fix line-height and spacing issues.  
-- Document changes here.  
-**Status:** TODO  
-**Log:**  
+**Scope:** Fonts, sizes, weights, and readability.
+**Tasks:**
+- Analyze current font stack.
+- Apply consistent font sizes for headings, body, buttons.
+- Fix line-height and spacing issues.
+- Document changes here.
+**Status:** TODO
+**Log:**
 
 ---
 
@@ -82,14 +82,16 @@
 ---
 
 ## Agent 7 — Footer
-**Scope:** Footer layout, links, alignment.  
-**Tasks:**  
-- Redesign footer with minimal style.  
-- Align links center or justified as needed.  
-- Apply palette + typography rules.  
-- Document changes.  
-**Status:** TODO  
-**Log:**  
+**Scope:** Footer layout, links, alignment.
+**Tasks:**
+- Redesign footer with minimal style.
+- Align links center or justified as needed.
+- Apply palette + typography rules.
+- Document changes.
+**Status:** DONE
+**Log:**
+- Implemented MAS-themed Footer component with accessible navigation and Support/Status/Docs links, ensuring palette contrast and focus visibility.
+- Lint surface flagged unrelated pre-existing issues in POS, Portal, PaperShader, StatusIndicator, and themeStore while verifying accessibility.
 
 ---
 

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+
+const footerLinks = [
+  {
+    label: 'Support',
+    href: '/support'
+  },
+  {
+    label: 'Status',
+    href: '/status'
+  },
+  {
+    label: 'Docs',
+    href: '/docs'
+  }
+];
+
+export const Footer: React.FC = () => {
+  const currentYear = new Date().getFullYear();
+
+  return (
+    <footer className="border-t border-line bg-surface-100/90 backdrop-blur-sm">
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-8 px-4 py-10 sm:px-6 lg:px-8">
+        <div className="flex flex-col gap-6 sm:flex-row sm:items-center sm:justify-between">
+          <div className="space-y-1">
+            <p className="text-sm font-semibold tracking-tight text-ink">MAS Suite</p>
+            <p className="text-sm text-muted">
+              Hospitality & retail operations, orchestrated.
+            </p>
+          </div>
+
+          <nav aria-label="Footer" className="flex flex-wrap items-center gap-4 text-sm font-medium">
+            {footerLinks.map(({ label, href }) => (
+              <a
+                key={label}
+                href={href}
+                className="text-ink transition-colors hover:text-primary-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
+              >
+                {label}
+              </a>
+            ))}
+          </nav>
+        </div>
+
+        <div className="flex flex-col gap-3 border-t border-line/60 pt-4 sm:flex-row sm:items-center sm:justify-between">
+          <p className="text-xs text-muted">&copy; {currentYear} MAS Technologies. All rights reserved.</p>
+          <p className="text-xs text-muted">
+            Built with resilient systems, accessible interfaces, and the MAS design language.
+          </p>
+        </div>
+      </div>
+    </footer>
+  );
+};


### PR DESCRIPTION
## Summary
- add a MAS-themed footer layout component with accessible support, status, and docs links
- record the footer work and lint findings in Agent 7's task board log

## Testing
- npm run lint *(fails: existing issues in POS, Portal, PaperShader, StatusIndicator, themeStore)*

------
https://chatgpt.com/codex/tasks/task_e_68d003cf16f88326981ed2a7aaf387fc