### PR TITLE
Enhance paper shader configuration and controls

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -118,10 +118,22 @@
 ---
 
 ## Agent 10 — Database/Functionality Checks
-**Scope:** Ensure functional logic and DB integration still work after UI changes.  
-**Tasks:**  
-- Verify forms still submit correctly.  
-- Confirm API/data fetching unaffected.  
-- Log any issues needing backend fixes.  
-**Status:** TODO  
-**Log:**  
+**Scope:** Ensure functional logic and DB integration still work after UI changes.
+**Tasks:**
+- Verify forms still submit correctly.
+- Confirm API/data fetching unaffected.
+- Log any issues needing backend fixes.
+**Status:** TODO
+**Log:**
+
+---
+
+## Agent 30 — Paper Shader
+**Scope:** Paper shader rendering, appearance controls, motion fallbacks.
+**Tasks:**
+- Extend shader state with per-surface tuning and reduced-motion defaults.
+- Update BackOffice controls with presets and reset actions.
+- Ensure renderer consumes the granular config and degrades gracefully when unsupported.
+**Status:** DONE
+**Log:**
+- Implemented per-surface shader state + tenant merge handling, refreshed BackOffice controls with presets/reset, and upgraded rendering to honor reduced-motion static fallbacks and WebGL failures. Lint still reports pre-existing issues in POS, Portal, and StatusIndicator.

--- a/src/components/apps/BackOffice.tsx
+++ b/src/components/apps/BackOffice.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Card, Button } from '@mas/ui';
-import { useTheme } from '../../stores/themeStore';
+import { useTheme, PaperShaderUpdate } from '../../stores/themeStore';
+import type { PaperShaderSurface } from '../../types';
 
 const themeModes = [
   { id: 'light', label: 'Light' },
@@ -8,20 +9,129 @@ const themeModes = [
   { id: 'auto', label: 'Auto' },
 ] as const;
 
-const paperSurfaces: Array<'background' | 'cards'> = ['background', 'cards'];
+const shaderPresets: Array<{
+  id: string;
+  label: string;
+  description: string;
+  config: PaperShaderUpdate;
+}> = [
+  {
+    id: 'subtle',
+    label: 'Subtle Grain',
+    description: 'Low-contrast texture suited for bright dining rooms.',
+    config: {
+      enabled: true,
+      surfaces: {
+        background: { intensity: 0.35, animationSpeed: 0.6, enabled: true },
+        cards: { intensity: 0.18, animationSpeed: 0, enabled: true },
+      },
+      reducedMotion: { mode: 'static', intensityMultiplier: 0.45 },
+    },
+  },
+  {
+    id: 'signature',
+    label: 'Signature',
+    description: 'Balanced grain with gentle motion for most venues.',
+    config: {
+      enabled: true,
+      surfaces: {
+        background: { intensity: 0.55, animationSpeed: 1, enabled: true },
+        cards: { intensity: 0.3, animationSpeed: 0.1, enabled: true },
+      },
+      reducedMotion: { mode: 'static', intensityMultiplier: 0.6 },
+    },
+  },
+  {
+    id: 'bold',
+    label: 'Bold Texture',
+    description: 'Higher grain for dim lounges and late-night service.',
+    config: {
+      enabled: true,
+      surfaces: {
+        background: { intensity: 0.72, animationSpeed: 1.35, enabled: true },
+        cards: { intensity: 0.42, animationSpeed: 0.2, enabled: true },
+      },
+      reducedMotion: { mode: 'static', intensityMultiplier: 0.5 },
+    },
+  },
+];
 
 export const BackOffice: React.FC = () => {
-  const { mode, paperShader, setMode, updatePaperShader } = useTheme();
+  const { mode, paperShader, setMode, updatePaperShader, resetPaperShader } = useTheme();
 
-  const toggleSurface = (surface: 'background' | 'cards') => {
-    const set = new Set(paperShader.surfaces);
-    if (set.has(surface)) {
-      set.delete(surface);
-    } else {
-      set.add(surface);
-    }
-    const next = Array.from(set);
-    updatePaperShader({ surfaces: next.length ? next : ['background'] });
+  const backgroundSurface = paperShader.surfaces.background;
+  const cardSurface = paperShader.surfaces.cards;
+
+  const toggleSurface = (surface: PaperShaderSurface) => {
+    updatePaperShader({
+      surfaces: {
+        [surface]: { enabled: !paperShader.surfaces[surface].enabled },
+      },
+    });
+  };
+
+  const handleIntensityChange = (surface: PaperShaderSurface, value: number) => {
+    updatePaperShader({
+      surfaces: {
+        [surface]: { intensity: value },
+      },
+    });
+  };
+
+  const handleSpeedChange = (surface: PaperShaderSurface, value: number) => {
+    updatePaperShader({
+      surfaces: {
+        [surface]: { animationSpeed: value },
+      },
+    });
+  };
+
+  const handlePreset = (config: PaperShaderUpdate) => {
+    updatePaperShader(config);
+  };
+
+  const isPresetActive = (config: PaperShaderUpdate) => {
+    const backgroundPreset = config.surfaces?.background;
+    const cardsPreset = config.surfaces?.cards;
+    const reducedPreset = config.reducedMotion;
+
+    const enabledMatches =
+      config.enabled === undefined || config.enabled === paperShader.enabled;
+
+    const backgroundMatches =
+      !backgroundPreset ||
+      (backgroundPreset.enabled === undefined ||
+        backgroundPreset.enabled === backgroundSurface.enabled) &&
+        (backgroundPreset.intensity === undefined ||
+          Math.abs(backgroundPreset.intensity - backgroundSurface.intensity) < 0.01) &&
+        (backgroundPreset.animationSpeed === undefined ||
+          Math.abs(backgroundPreset.animationSpeed - backgroundSurface.animationSpeed) < 0.05);
+
+    const cardsMatches =
+      !cardsPreset ||
+      (cardsPreset.enabled === undefined || cardsPreset.enabled === cardSurface.enabled) &&
+        (cardsPreset.intensity === undefined ||
+          Math.abs(cardsPreset.intensity - cardSurface.intensity) < 0.01) &&
+        (cardsPreset.animationSpeed === undefined ||
+          Math.abs(cardsPreset.animationSpeed - cardSurface.animationSpeed) < 0.05);
+
+    const reducedMatches =
+      !reducedPreset ||
+      (reducedPreset.mode === undefined || reducedPreset.mode === paperShader.reducedMotion.mode) &&
+        (reducedPreset.intensityMultiplier === undefined ||
+          Math.abs(
+            reducedPreset.intensityMultiplier - paperShader.reducedMotion.intensityMultiplier
+          ) < 0.01);
+
+    return enabledMatches && backgroundMatches && cardsMatches && reducedMatches;
+  };
+
+  const handleReducedMotionMode = (mode: 'static' | 'disabled') => {
+    updatePaperShader({ reducedMotion: { mode } });
+  };
+
+  const handleReducedMotionIntensity = (value: number) => {
+    updatePaperShader({ reducedMotion: { intensityMultiplier: value } });
   };
 
   return (
@@ -64,71 +174,191 @@ export const BackOffice: React.FC = () => {
           </Card>
 
           <Card className="space-y-6">
-            <div className="flex items-center justify-between gap-4">
+            <div className="flex flex-wrap items-start justify-between gap-4">
               <div>
                 <h2 className="text-xl font-semibold">Paper Shader</h2>
                 <p className="text-muted text-sm">
-                  Toggle the tactile grain layer and fine-tune its intensity and animation speed.
+                  Toggle the tactile grain layer, tune per-surface intensity, and define motion
+                  fallbacks. Updates apply instantly across the suite.
                 </p>
               </div>
-              <Button
-                variant={paperShader.enabled ? 'primary' : 'outline'}
-                onClick={() => updatePaperShader({ enabled: !paperShader.enabled })}
-              >
-                {paperShader.enabled ? 'Enabled' : 'Disabled'}
-              </Button>
+              <div className="flex items-center gap-2">
+                <Button variant="ghost" size="sm" onClick={resetPaperShader}>
+                  Reset
+                </Button>
+                <Button
+                  variant={paperShader.enabled ? 'primary' : 'outline'}
+                  onClick={() => updatePaperShader({ enabled: !paperShader.enabled })}
+                >
+                  {paperShader.enabled ? 'Enabled' : 'Disabled'}
+                </Button>
+              </div>
             </div>
 
-            <div className="space-y-4">
+            <div className="space-y-3">
+              <h3 className="text-sm font-medium text-ink">Presets</h3>
+              <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+                {shaderPresets.map((preset) => {
+                  const active = isPresetActive(preset.config);
+                  return (
+                    <Button
+                      key={preset.id}
+                      variant={active ? 'primary' : 'secondary'}
+                      className="h-auto w-full flex-col items-start justify-start gap-1 text-left"
+                      onClick={() => handlePreset(preset.config)}
+                    >
+                      <span className="text-sm font-semibold">{preset.label}</span>
+                      <span className="text-xs font-normal text-muted">{preset.description}</span>
+                    </Button>
+                  );
+                })}
+              </div>
+            </div>
+
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="rounded-lg border border-line/70 bg-surface-200/40 p-4 space-y-4">
+                <div className="flex items-center justify-between gap-2">
+                  <div>
+                    <h3 className="text-sm font-semibold text-ink">Background</h3>
+                    <p className="text-xs text-muted">
+                      Full-viewport grain rendered beneath every screen.
+                    </p>
+                  </div>
+                  <Button
+                    size="sm"
+                    variant={backgroundSurface.enabled ? 'primary' : 'outline'}
+                    onClick={() => toggleSurface('background')}
+                  >
+                    {backgroundSurface.enabled ? 'Active' : 'Inactive'}
+                  </Button>
+                </div>
+                <label className="flex flex-col gap-2">
+                  <span className="text-xs font-medium text-ink">Intensity</span>
+                  <input
+                    type="range"
+                    min={0}
+                    max={1}
+                    step={0.05}
+                    value={backgroundSurface.intensity}
+                    onChange={(event) =>
+                      handleIntensityChange('background', parseFloat(event.target.value))
+                    }
+                    className="w-full accent-primary-500"
+                  />
+                  <span className="text-[11px] text-muted tracking-wide">
+                    {backgroundSurface.intensity.toFixed(2)}
+                  </span>
+                </label>
+                <label className="flex flex-col gap-2">
+                  <span className="text-xs font-medium text-ink">Animation speed</span>
+                  <input
+                    type="range"
+                    min={0}
+                    max={2}
+                    step={0.05}
+                    value={backgroundSurface.animationSpeed}
+                    onChange={(event) =>
+                      handleSpeedChange('background', parseFloat(event.target.value))
+                    }
+                    className="w-full accent-primary-500"
+                  />
+                  <span className="text-[11px] text-muted tracking-wide">
+                    {backgroundSurface.animationSpeed.toFixed(2)}x
+                  </span>
+                </label>
+              </div>
+
+              <div className="rounded-lg border border-line/70 bg-surface-200/40 p-4 space-y-4">
+                <div className="flex items-center justify-between gap-2">
+                  <div>
+                    <h3 className="text-sm font-semibold text-ink">Cards & surfaces</h3>
+                    <p className="text-xs text-muted">
+                      Static grain for elevated cards, modals, and panels.
+                    </p>
+                  </div>
+                  <Button
+                    size="sm"
+                    variant={cardSurface.enabled ? 'primary' : 'outline'}
+                    onClick={() => toggleSurface('cards')}
+                  >
+                    {cardSurface.enabled ? 'Active' : 'Inactive'}
+                  </Button>
+                </div>
+                <label className="flex flex-col gap-2">
+                  <span className="text-xs font-medium text-ink">Intensity</span>
+                  <input
+                    type="range"
+                    min={0}
+                    max={1}
+                    step={0.05}
+                    value={cardSurface.intensity}
+                    onChange={(event) =>
+                      handleIntensityChange('cards', parseFloat(event.target.value))
+                    }
+                    className="w-full accent-primary-500"
+                  />
+                  <span className="text-[11px] text-muted tracking-wide">
+                    {cardSurface.intensity.toFixed(2)}
+                  </span>
+                </label>
+                <label className="flex flex-col gap-2">
+                  <span className="text-xs font-medium text-ink">Animation speed</span>
+                  <input
+                    type="range"
+                    min={0}
+                    max={1}
+                    step={0.05}
+                    value={cardSurface.animationSpeed}
+                    onChange={(event) =>
+                      handleSpeedChange('cards', parseFloat(event.target.value))
+                    }
+                    className="w-full accent-primary-500"
+                  />
+                  <span className="text-[11px] text-muted tracking-wide">
+                    {cardSurface.animationSpeed.toFixed(2)}x
+                  </span>
+                </label>
+              </div>
+            </div>
+
+            <div className="rounded-lg border border-line/70 bg-surface-200/40 p-4 space-y-4">
+              <div>
+                <h3 className="text-sm font-semibold text-ink">Reduced motion fallback</h3>
+                <p className="text-xs text-muted">
+                  Honour <code className="font-mono text-[10px]">prefers-reduced-motion</code> by
+                  swapping to a static grain or disabling the layer.
+                </p>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                {(['static', 'disabled'] as const).map((modeOption) => (
+                  <Button
+                    key={modeOption}
+                    size="sm"
+                    variant={paperShader.reducedMotion.mode === modeOption ? 'primary' : 'outline'}
+                    onClick={() => handleReducedMotionMode(modeOption)}
+                  >
+                    {modeOption === 'static' ? 'Static grain' : 'Turn off'}
+                  </Button>
+                ))}
+              </div>
               <label className="flex flex-col gap-2">
-                <span className="text-sm font-medium text-ink">Grain intensity</span>
+                <span className="text-xs font-medium text-ink">Static grain strength</span>
                 <input
                   type="range"
                   min={0}
                   max={1}
                   step={0.05}
-                  value={paperShader.intensity}
+                  value={paperShader.reducedMotion.intensityMultiplier}
                   onChange={(event) =>
-                    updatePaperShader({ intensity: parseFloat(event.target.value) })
+                    handleReducedMotionIntensity(parseFloat(event.target.value))
                   }
                   className="w-full accent-primary-500"
+                  disabled={paperShader.reducedMotion.mode === 'disabled'}
                 />
-                <span className="text-xs text-muted">{paperShader.intensity.toFixed(2)}</span>
+                <span className="text-[11px] text-muted tracking-wide">
+                  {paperShader.reducedMotion.intensityMultiplier.toFixed(2)}
+                </span>
               </label>
-
-              <label className="flex flex-col gap-2">
-                <span className="text-sm font-medium text-ink">Animation speed</span>
-                <input
-                  type="range"
-                  min={0}
-                  max={3}
-                  step={0.1}
-                  value={paperShader.animationSpeed}
-                  onChange={(event) =>
-                    updatePaperShader({ animationSpeed: parseFloat(event.target.value) })
-                  }
-                  className="w-full accent-primary-500"
-                />
-                <span className="text-xs text-muted">{paperShader.animationSpeed.toFixed(1)}x</span>
-              </label>
-            </div>
-
-            <div>
-              <h3 className="text-sm font-medium text-ink mb-2">Apply shader to</h3>
-              <div className="flex flex-wrap gap-2">
-                {paperSurfaces.map((surface) => {
-                  const active = paperShader.surfaces.includes(surface);
-                  return (
-                    <Button
-                      key={surface}
-                      variant={active ? 'primary' : 'outline'}
-                      onClick={() => toggleSurface(surface)}
-                    >
-                      {surface === 'background' ? 'Background' : 'Cards'}
-                    </Button>
-                  );
-                })}
-              </div>
             </div>
           </Card>
         </div>

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -22,16 +22,13 @@ export const AppShell: React.FC = () => {
   const currentApp = appConfigs.find((app) => location.pathname.startsWith(app.route));
   const isPortal = location.pathname === '/portal' || location.pathname === '/';
 
-  const shouldRenderPaper = paperShader.enabled && paperShader.surfaces.includes('background');
+  const shouldRenderPaper =
+    paperShader.enabled && paperShader.surfaces.background.enabled && paperShader.surfaces.background.intensity > 0;
 
   return (
     <div className="min-h-screen bg-bg-dust text-ink relative">
       {shouldRenderPaper && (
-        <PaperShader
-          intensity={paperShader.intensity}
-          animationSpeed={paperShader.animationSpeed}
-          surfaces={paperShader.surfaces}
-        />
+        <PaperShader />
       )}
 
       <header className="bg-surface-100/80 backdrop-blur-sm border-b border-line sticky top-0 z-40">

--- a/src/components/ui/PaperShader.tsx
+++ b/src/components/ui/PaperShader.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect, useState } from 'react';
+import React, { useRef, useEffect, useState, useMemo } from 'react';
 import * as THREE from 'three';
 import { useThemeStore } from '../../stores/themeStore';
 
@@ -77,6 +77,9 @@ void main() {
 }
 `;
 
+const staticNoiseTexture =
+  "url('data:image/svg+xml,%3Csvg xmlns=\\'http://www.w3.org/2000/svg\\' width=\\'4\\' height=\\'4\\' viewBox=\\'0 0 4 4\\'%3E%3Cpath fill=\\'#000\\' fill-opacity=\\'0.02\\' d=\\'M1 3h1v1H1V3zm2-2h1v1H3V1z\\'%3E%3C/path%3E%3C/svg%3E')";
+
 export const PaperShader: React.FC<PaperShaderProps> = ({
   intensity,
   animationSpeed,
@@ -85,48 +88,81 @@ export const PaperShader: React.FC<PaperShaderProps> = ({
   className = '',
 }) => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
-  const rendererRef = useRef<THREE.WebGLRenderer | null>(null);
-  const sceneRef = useRef<THREE.Scene | null>(null);
-  const materialRef = useRef<THREE.ShaderMaterial | null>(null);
   const animationIdRef = useRef<number | null>(null);
   const [isSupported, setIsSupported] = useState(true);
-  const [isVisible, setIsVisible] = useState(true);
+  const [hasPerformanceFallback, setHasPerformanceFallback] = useState(false);
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
 
   const paperShader = useThemeStore((state) => state.paperShader);
 
-  const effectiveIntensity = intensity ?? paperShader.intensity;
-  const effectiveSpeed = animationSpeed ?? paperShader.animationSpeed;
-  const effectiveEnabled =
-    (enabled ?? paperShader.enabled) &&
-    (surfaces ?? paperShader.surfaces).includes('background');
-  const effectiveSurfaces = surfaces ?? paperShader.surfaces;
+  const surfacesOverride = useMemo(() => (surfaces ? new Set(surfaces) : null), [surfaces]);
+
+  const backgroundConfig = paperShader.surfaces.background;
+  const resolvedBackgroundEnabled =
+    surfacesOverride !== null ? surfacesOverride.has('background') : backgroundConfig.enabled;
+  const resolvedBackgroundIntensity = intensity ?? backgroundConfig.intensity;
+  const resolvedBackgroundSpeed = animationSpeed ?? backgroundConfig.animationSpeed;
+  const overallEnabled = enabled ?? paperShader.enabled;
+  const backgroundActive =
+    overallEnabled && resolvedBackgroundEnabled && resolvedBackgroundIntensity > 0;
+
+  const reducedMotionMode = paperShader.reducedMotion.mode;
+  const reducedMotionMultiplier = paperShader.reducedMotion.intensityMultiplier;
 
   useEffect(() => {
-    if (!effectiveEnabled || !canvasRef.current) {
+    if (typeof window === 'undefined') {
       return;
     }
 
+    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const updatePreference = () => setPrefersReducedMotion(mediaQuery.matches);
+
+    updatePreference();
+    mediaQuery.addEventListener('change', updatePreference);
+
+    return () => {
+      mediaQuery.removeEventListener('change', updatePreference);
+    };
+  }, []);
+
+  const disableForReducedMotion = prefersReducedMotion && reducedMotionMode === 'disabled';
+  const staticForReducedMotion = prefersReducedMotion && reducedMotionMode === 'static';
+  const shouldAttemptCanvas = backgroundActive && !disableForReducedMotion && !staticForReducedMotion;
+
+  useEffect(() => {
+    if (!shouldAttemptCanvas || !canvasRef.current || !isSupported) {
+      return;
+    }
+
+    setHasPerformanceFallback(false);
+
     const canvas = canvasRef.current;
+    let renderer: THREE.WebGLRenderer | null = null;
+    let scene: THREE.Scene | null = null;
+    let material: THREE.ShaderMaterial | null = null;
+    let geometry: THREE.PlaneGeometry | null = null;
+    let camera: THREE.OrthographicCamera | null = null;
+    let disposed = false;
 
     try {
-      const renderer = new THREE.WebGLRenderer({
+      renderer = new THREE.WebGLRenderer({
         canvas,
         alpha: true,
         antialias: false,
         powerPreference: 'low-power',
       });
 
-      const scene = new THREE.Scene();
-      const camera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0.1, 10);
+      scene = new THREE.Scene();
+      camera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0.1, 10);
       camera.position.z = 1;
 
-      const geometry = new THREE.PlaneGeometry(2, 2);
-      const material = new THREE.ShaderMaterial({
+      geometry = new THREE.PlaneGeometry(2, 2);
+      material = new THREE.ShaderMaterial({
         vertexShader,
         fragmentShader,
         uniforms: {
           uTime: { value: 0 },
-          uIntensity: { value: effectiveIntensity },
+          uIntensity: { value: resolvedBackgroundIntensity },
           uResolution: { value: new THREE.Vector2(window.innerWidth, window.innerHeight) },
         },
         transparent: true,
@@ -135,88 +171,111 @@ export const PaperShader: React.FC<PaperShaderProps> = ({
 
       const mesh = new THREE.Mesh(geometry, material);
       scene.add(mesh);
-
-      rendererRef.current = renderer;
-      sceneRef.current = scene;
-      materialRef.current = material;
-
-      let frameCount = 0;
-      let lastTime = performance.now();
-      let averageFrameTime = 0;
-
-      const animate = () => {
-        const currentTime = performance.now();
-        const deltaTime = currentTime - lastTime;
-
-        frameCount += 1;
-        averageFrameTime = (averageFrameTime * (frameCount - 1) + deltaTime) / frameCount;
-
-        if (frameCount > 60 && averageFrameTime > 2) {
-          setIsVisible(false);
-          console.warn('Paper shader disabled due to performance');
-          return;
-        }
-
-        if (material.uniforms) {
-          material.uniforms.uTime.value = currentTime * 0.001 * effectiveSpeed;
-          material.uniforms.uIntensity.value = effectiveIntensity;
-        }
-
-        renderer.render(scene, camera);
-        lastTime = currentTime;
-
-        animationIdRef.current = requestAnimationFrame(animate);
-      };
-
-      const handleResize = () => {
-        const width = window.innerWidth;
-        const height = window.innerHeight;
-
-        renderer.setSize(width, height, false);
-        if (material.uniforms) {
-          material.uniforms.uResolution.value.set(width, height);
-        }
-      };
-
-      const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-      if (prefersReducedMotion) {
-        setIsVisible(false);
-        return;
-      }
-
-      handleResize();
-      window.addEventListener('resize', handleResize);
-
-      animate();
-
-      return () => {
-        window.removeEventListener('resize', handleResize);
-        if (animationIdRef.current) {
-          cancelAnimationFrame(animationIdRef.current);
-        }
-        renderer.dispose();
-        material.dispose();
-        geometry.dispose();
-      };
     } catch (error) {
       console.warn('Paper shader not supported:', error);
       setIsSupported(false);
+      return;
     }
-  }, [effectiveEnabled, effectiveIntensity, effectiveSpeed]);
 
-  if (!effectiveEnabled || !isSupported || !isVisible) {
-    const showFallback = effectiveSurfaces.includes('background');
+    if (!renderer || !scene || !material || !geometry || !camera) {
+      return;
+    }
 
-    return showFallback ? (
+    const handleResize = () => {
+      const width = window.innerWidth;
+      const height = window.innerHeight;
+
+      renderer.setSize(width, height, false);
+      material.uniforms.uResolution.value.set(width, height);
+    };
+
+    const stopRenderer = () => {
+      if (disposed) {
+        return;
+      }
+      disposed = true;
+      window.removeEventListener('resize', handleResize);
+      if (animationIdRef.current) {
+        cancelAnimationFrame(animationIdRef.current);
+        animationIdRef.current = null;
+      }
+      renderer.dispose();
+      material.dispose();
+      geometry.dispose();
+    };
+
+    let frameCount = 0;
+    let lastTime = performance.now();
+    let averageFrameTime = 0;
+
+    const animate = () => {
+      if (disposed) {
+        return;
+      }
+
+      const currentTime = performance.now();
+      const deltaTime = currentTime - lastTime;
+
+      frameCount += 1;
+      averageFrameTime = (averageFrameTime * (frameCount - 1) + deltaTime) / frameCount;
+
+      if (frameCount > 90 && averageFrameTime > 2.4) {
+        setHasPerformanceFallback(true);
+        stopRenderer();
+        return;
+      }
+
+      material.uniforms.uTime.value = currentTime * 0.001 * resolvedBackgroundSpeed;
+      material.uniforms.uIntensity.value = resolvedBackgroundIntensity;
+
+      renderer.render(scene, camera);
+      lastTime = currentTime;
+      animationIdRef.current = requestAnimationFrame(animate);
+    };
+
+    handleResize();
+    window.addEventListener('resize', handleResize);
+    animate();
+
+    return () => {
+      stopRenderer();
+    };
+  }, [shouldAttemptCanvas, resolvedBackgroundIntensity, resolvedBackgroundSpeed, isSupported]);
+
+  const shouldRenderStaticFallback =
+    backgroundActive && (staticForReducedMotion || !isSupported || hasPerformanceFallback);
+
+  const fallbackMultiplier = staticForReducedMotion ? reducedMotionMultiplier : 0.35;
+  const fallbackIntensity = Math.min(
+    1,
+    Math.max(0, resolvedBackgroundIntensity * fallbackMultiplier)
+  );
+  const fallbackOpacity = Math.min(0.45, fallbackIntensity * 0.4);
+  const fallbackTint = Math.min(0.2, fallbackIntensity * 0.3);
+
+  if (!backgroundActive) {
+    return null;
+  }
+
+  if (shouldRenderStaticFallback && fallbackOpacity > 0) {
+    return (
       <div
         className={`fixed inset-0 pointer-events-none ${className}`}
         style={{
-          background:
-            "url('data:image/svg+xml,%3Csvg xmlns=\'http://www.w3.org/2000/svg\' width=\'4\' height=\'4\' viewBox=\'0 0 4 4\'%3E%3Cpath fill=\'#000\' fill-opacity=\'0.02\' d=\'M1 3h1v1H1V3zm2-2h1v1H3V1z\'%3E%3C/path%3E%3C/svg%3E')",
-          opacity: effectiveIntensity * 0.3,
+          zIndex: -1,
+          backgroundImage:
+            "linear-gradient(135deg, rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0)), " +
+            staticNoiseTexture,
+          backgroundSize: 'cover, 4px 4px',
+          opacity: fallbackOpacity,
+          backgroundColor: `rgba(248, 244, 240, ${fallbackTint.toFixed(3)})`,
         }}
       />
-    ) : null;
+    );
+  }
+
+  if (!shouldAttemptCanvas || !isSupported || hasPerformanceFallback) {
+    return null;
   }
 
   return (

--- a/src/data/mockData.ts
+++ b/src/data/mockData.ts
@@ -9,9 +9,22 @@ export const mockTenant: Tenant = {
     theme: 'light',
     paperShader: {
       enabled: true,
-      intensity: 0.5,
-      animationSpeed: 1.0,
-      surfaces: ['background', 'cards']
+      surfaces: {
+        background: {
+          enabled: true,
+          intensity: 0.5,
+          animationSpeed: 1,
+        },
+        cards: {
+          enabled: true,
+          intensity: 0.32,
+          animationSpeed: 0,
+        },
+      },
+      reducedMotion: {
+        mode: 'static',
+        intensityMultiplier: 0.55,
+      },
     }
   }
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,16 +5,30 @@ export interface Tenant {
   settings: TenantSettings;
 }
 
+export type PaperShaderSurface = 'background' | 'cards';
+
+export interface PaperShaderSurfaceConfig {
+  enabled: boolean;
+  intensity: number;
+  animationSpeed: number;
+}
+
+export interface PaperShaderReducedMotionConfig {
+  mode: 'static' | 'disabled';
+  intensityMultiplier: number;
+}
+
+export interface PaperShaderSettings {
+  enabled: boolean;
+  surfaces: Record<PaperShaderSurface, PaperShaderSurfaceConfig>;
+  reducedMotion: PaperShaderReducedMotionConfig;
+}
+
 export interface TenantSettings {
   currency: string;
   timezone: string;
   theme: 'light' | 'dark' | 'auto';
-  paperShader: {
-    enabled: boolean;
-    intensity: number;
-    animationSpeed: number;
-    surfaces: ('background' | 'cards')[];
-  };
+  paperShader: PaperShaderSettings;
 }
 
 export interface Store {


### PR DESCRIPTION
## Summary
- add per-surface paper shader state with reduced-motion options and safe persistence
- update the PaperShader renderer, ThemeProvider, and AppShell to honor granular settings and static fallbacks
- refresh BackOffice controls with presets, per-surface sliders, reduced-motion adjustments, and reset while documenting the work in Agent 30

## Testing
- npm run lint *(fails: existing lint errors in POS.tsx, Portal.tsx, StatusIndicator.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68cffb48b170832694c53748a93a6318