### PR TITLE
Integrate footer into app shell

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -82,14 +82,15 @@
 ---
 
 ## Agent 7 — Footer
-**Scope:** Footer layout, links, alignment.  
-**Tasks:**  
-- Redesign footer with minimal style.  
-- Align links center or justified as needed.  
-- Apply palette + typography rules.  
-- Document changes.  
-**Status:** TODO  
-**Log:**  
+**Scope:** Footer layout, links, alignment.
+**Tasks:**
+- Redesign footer with minimal style.
+- Align links center or justified as needed.
+- Apply palette + typography rules.
+- Document changes.
+**Status:** DONE
+**Log:**
+- Integrated the new Footer component into the AppShell, ensured it sits above the paper shader with a negative z-index class, and confirmed layout scroll space by switching the shell to a flex column. Palette tokens applied to navigation links. `npm run build` completes, so scrolling with the footer in place compiles without runtime errors; interactive scroll smoke test limited to structural review in this environment.
 
 ---
 

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -10,6 +10,7 @@ import { useAuthStore } from '../../stores/authStore';
 import { useThemeStore } from '../../stores/themeStore';
 import { appConfigs } from '../../config/apps';
 import { ThemeModeToggle } from '../ui/ThemeModeToggle';
+import { Footer } from './Footer';
 
 const MotionButton = motion(Button);
 
@@ -25,12 +26,13 @@ export const AppShell: React.FC = () => {
   const shouldRenderPaper = paperShader.enabled && paperShader.surfaces.includes('background');
 
   return (
-    <div className="min-h-screen bg-bg-dust text-ink relative">
+    <div className="relative flex min-h-screen flex-col bg-bg-dust text-ink">
       {shouldRenderPaper && (
         <PaperShader
           intensity={paperShader.intensity}
           animationSpeed={paperShader.animationSpeed}
           surfaces={paperShader.surfaces}
+          className="-z-10"
         />
       )}
 
@@ -86,11 +88,13 @@ export const AppShell: React.FC = () => {
         </div>
       </header>
 
-      <main className="relative z-10">
+      <main className="relative z-10 flex-1">
         <PageTransition>
           <Outlet />
         </PageTransition>
       </main>
+
+      <Footer />
     </div>
   );
 };

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+const navigationLinks = [
+  { label: 'Suite Launcher', to: '/portal' },
+  { label: 'Point of Sale', to: '/pos' },
+  { label: 'Back Office', to: '/backoffice' },
+  { label: 'Reports', to: '/reports' },
+];
+
+export const Footer: React.FC = () => {
+  const currentYear = new Date().getFullYear();
+
+  return (
+    <footer className="relative z-20 border-t border-line bg-surface-100/80 backdrop-blur">
+      <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-4 py-8 text-sm md:flex-row md:items-center md:justify-between">
+        <div className="space-y-2 text-center md:text-left">
+          <p className="text-base font-semibold text-ink">Maas Platform</p>
+          <p className="text-sm text-muted">
+            Operational tools crafted for hospitality teams. Stay connected and in control from floor to back office.
+          </p>
+          <p className="text-xs text-muted/80">© {currentYear} Maas. All rights reserved.</p>
+        </div>
+
+        <nav aria-label="Footer navigation" className="flex flex-wrap justify-center gap-4 text-sm font-medium md:justify-end">
+          {navigationLinks.map((link) => (
+            <Link
+              key={link.to}
+              to={link.to}
+              className="rounded-md px-2 py-1 text-muted transition-colors duration-200 hover:text-primary-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 focus-visible:ring-offset-bg-dust"
+            >
+              {link.label}
+            </Link>
+          ))}
+        </nav>
+      </div>
+    </footer>
+  );
+};
+
+export default Footer;


### PR DESCRIPTION
## Summary
- add a dedicated footer layout component with navigation links styled to match the palette
- render the footer within the app shell and move the paper shader behind the content stack
- record the footer work in Agent 7’s tracker

## Testing
- npm run build
- npm run lint *(fails: pre-existing lint issues outside the updated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d003cfa7dc8326a994d4e4042a7c72