### PR TITLE
feat: establish MAS typography scale

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -16,8 +16,8 @@
 - Fix misaligned sections, spacing, and grid inconsistencies.  
 - Improve responsiveness (mobile/tablet/desktop).  
 - Keep existing functionality untouched.  
-**Status:** TODO  
-**Log:**  
+**Status:** TODO
+**Log:**
 
 ---
 
@@ -28,8 +28,8 @@
 - Replace off-palette values with correct ones.  
 - Ensure Tailwind config and global tokens are updated.  
 - Verify consistency across all components.  
-**Status:** TODO  
-**Log:**  
+**Status:** TODO
+**Log:**
 
 ---
 
@@ -40,8 +40,10 @@
 - Apply consistent font sizes for headings, body, buttons.  
 - Fix line-height and spacing issues.  
 - Document changes here.  
-**Status:** TODO  
-**Log:**  
+**Status:** DONE
+**Log:**
+- Established MAS typography scale (2xs 11px → 7xl 68px) with shared CSS variables, helper classes, and Tailwind font-size tokens to keep headings and body text consistent.
+- Ran `npm run lint` after changes; command failed because of pre-existing lint errors in POS.tsx, Portal.tsx, PaperShader.tsx, StatusIndicator.tsx, and themeStore.ts (unused vars, `any`, escape characters).
 
 ---
 

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,6 @@
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
 @import './styles/tokens.css';
+@import './styles/typography.css';
 
 @tailwind base;
 @tailwind components;

--- a/src/styles/typography.css
+++ b/src/styles/typography.css
@@ -1,0 +1,148 @@
+:root {
+  --font-family-sans: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+
+  --font-weight-regular: 400;
+  --font-weight-medium: 500;
+  --font-weight-semibold: 600;
+  --font-weight-bold: 700;
+
+  --line-height-tight: 1.1;
+  --line-height-snug: 1.25;
+  --line-height-relaxed: 1.5;
+  --line-height-loose: 1.7;
+
+  --tracking-tight: -0.02em;
+  --tracking-normal: 0em;
+  --tracking-wide: 0.04em;
+
+  --font-size-2xs: 0.6875rem;
+  --font-size-xs: 0.75rem;
+  --font-size-sm: 0.875rem;
+  --font-size-md: 1rem;
+  --font-size-lg: 1.125rem;
+  --font-size-xl: 1.25rem;
+  --font-size-2xl: 1.5rem;
+  --font-size-3xl: 1.875rem;
+  --font-size-4xl: 2.25rem;
+  --font-size-5xl: 2.75rem;
+  --font-size-6xl: 3.5rem;
+  --font-size-7xl: 4.25rem;
+}
+
+.text-display-xl {
+  font-family: var(--font-family-sans);
+  font-size: var(--font-size-7xl);
+  line-height: var(--line-height-tight);
+  letter-spacing: var(--tracking-tight);
+  font-weight: var(--font-weight-semibold);
+}
+
+.text-display-lg {
+  font-family: var(--font-family-sans);
+  font-size: var(--font-size-6xl);
+  line-height: var(--line-height-tight);
+  letter-spacing: var(--tracking-tight);
+  font-weight: var(--font-weight-semibold);
+}
+
+.text-display-md {
+  font-family: var(--font-family-sans);
+  font-size: var(--font-size-5xl);
+  line-height: var(--line-height-snug);
+  letter-spacing: var(--tracking-tight);
+  font-weight: var(--font-weight-semibold);
+}
+
+.text-display-sm {
+  font-family: var(--font-family-sans);
+  font-size: var(--font-size-4xl);
+  line-height: var(--line-height-snug);
+  letter-spacing: var(--tracking-tight);
+  font-weight: var(--font-weight-semibold);
+}
+
+.text-title-lg {
+  font-family: var(--font-family-sans);
+  font-size: var(--font-size-3xl);
+  line-height: var(--line-height-snug);
+  letter-spacing: var(--tracking-tight);
+  font-weight: var(--font-weight-semibold);
+}
+
+.text-title {
+  font-family: var(--font-family-sans);
+  font-size: var(--font-size-2xl);
+  line-height: var(--line-height-snug);
+  letter-spacing: var(--tracking-tight);
+  font-weight: var(--font-weight-semibold);
+}
+
+.text-subtitle {
+  font-family: var(--font-family-sans);
+  font-size: var(--font-size-xl);
+  line-height: var(--line-height-snug);
+  letter-spacing: var(--tracking-normal);
+  font-weight: var(--font-weight-medium);
+}
+
+.text-body-lg {
+  font-family: var(--font-family-sans);
+  font-size: var(--font-size-lg);
+  line-height: var(--line-height-relaxed);
+  letter-spacing: var(--tracking-normal);
+  font-weight: var(--font-weight-regular);
+}
+
+.text-body {
+  font-family: var(--font-family-sans);
+  font-size: var(--font-size-md);
+  line-height: var(--line-height-relaxed);
+  letter-spacing: var(--tracking-normal);
+  font-weight: var(--font-weight-regular);
+}
+
+.text-body-sm {
+  font-family: var(--font-family-sans);
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-relaxed);
+  letter-spacing: var(--tracking-normal);
+  font-weight: var(--font-weight-regular);
+}
+
+.text-caption {
+  font-family: var(--font-family-sans);
+  font-size: var(--font-size-xs);
+  line-height: var(--line-height-relaxed);
+  letter-spacing: var(--tracking-wide);
+  font-weight: var(--font-weight-medium);
+}
+
+.text-micro {
+  font-family: var(--font-family-sans);
+  font-size: var(--font-size-2xs);
+  line-height: var(--line-height-loose);
+  letter-spacing: var(--tracking-wide);
+  font-weight: var(--font-weight-medium);
+}
+
+.text-uppercase {
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+  font-weight: var(--font-weight-semibold);
+}
+
+.font-regular {
+  font-weight: var(--font-weight-regular);
+}
+
+.font-medium {
+  font-weight: var(--font-weight-medium);
+}
+
+.font-semibold {
+  font-weight: var(--font-weight-semibold);
+}
+
+.font-bold {
+  font-weight: var(--font-weight-bold);
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -30,6 +30,20 @@ export default {
       fontFamily: {
         sans: ['"Inter"', 'system-ui', '-apple-system', 'BlinkMacSystemFont', '"Segoe UI"', 'sans-serif'],
       },
+      fontSize: {
+        '2xs': ['var(--font-size-2xs)', { lineHeight: 'var(--line-height-loose)', letterSpacing: 'var(--tracking-wide)' }],
+        xs: ['var(--font-size-xs)', { lineHeight: 'var(--line-height-relaxed)', letterSpacing: 'var(--tracking-wide)' }],
+        sm: ['var(--font-size-sm)', { lineHeight: 'var(--line-height-relaxed)', letterSpacing: 'var(--tracking-normal)' }],
+        base: ['var(--font-size-md)', { lineHeight: 'var(--line-height-relaxed)', letterSpacing: 'var(--tracking-normal)' }],
+        lg: ['var(--font-size-lg)', { lineHeight: 'var(--line-height-relaxed)', letterSpacing: 'var(--tracking-normal)' }],
+        xl: ['var(--font-size-xl)', { lineHeight: 'var(--line-height-snug)', letterSpacing: 'calc(var(--tracking-tight) / 2)' }],
+        '2xl': ['var(--font-size-2xl)', { lineHeight: 'var(--line-height-snug)', letterSpacing: 'var(--tracking-tight)' }],
+        '3xl': ['var(--font-size-3xl)', { lineHeight: 'var(--line-height-snug)', letterSpacing: 'var(--tracking-tight)' }],
+        '4xl': ['var(--font-size-4xl)', { lineHeight: 'var(--line-height-snug)', letterSpacing: 'var(--tracking-tight)' }],
+        '5xl': ['var(--font-size-5xl)', { lineHeight: 'var(--line-height-tight)', letterSpacing: 'var(--tracking-tight)' }],
+        '6xl': ['var(--font-size-6xl)', { lineHeight: 'var(--line-height-tight)', letterSpacing: 'var(--tracking-tight)' }],
+        '7xl': ['var(--font-size-7xl)', { lineHeight: 'var(--line-height-tight)', letterSpacing: 'var(--tracking-tight)' }],
+      },
       borderRadius: {
         sm: 'var(--radius-sm)',
         md: 'var(--radius-md)',


### PR DESCRIPTION
## Summary
- add MAS typography tokens and helper classes
- wire the new MAS type scale into Tailwind font-size utilities and global styles
- document the typography scale completion for Agent 3

## Testing
- npm run lint *(fails: existing unused variables and escape-character lint errors in POS.tsx, Portal.tsx, PaperShader.tsx, StatusIndicator.tsx, and themeStore.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68d003c938e88326bc6cd467a1d03c49