### PR TITLE
feat: add shared layout container

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -16,8 +16,9 @@
 - Fix misaligned sections, spacing, and grid inconsistencies.  
 - Improve responsiveness (mobile/tablet/desktop).  
 - Keep existing functionality untouched.  
-**Status:** TODO  
-**Log:**  
+**Status:** DONE
+**Log:**
+- Introduced a flex-based AppShell wrapper with a growing main area, added a shared PageContainer gutter, and wrapped the portal/backoffice entries to confirm consistent padding at sm/md/lg breakpoints via px-4/sm:px-6/lg:px-8 tokens.
 
 ---
 

--- a/src/components/apps/BackOffice.tsx
+++ b/src/components/apps/BackOffice.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Card, Button } from '@mas/ui';
+import { PageContainer } from '../layout/PageContainer';
 import { useTheme } from '../../stores/themeStore';
 
 const themeModes = [
@@ -25,7 +26,7 @@ export const BackOffice: React.FC = () => {
   };
 
   return (
-    <div className="p-6">
+    <PageContainer>
       <div className="max-w-5xl mx-auto space-y-8">
         <div>
           <h1 className="text-3xl font-bold mb-2">Backoffice Settings</h1>
@@ -154,6 +155,6 @@ export const BackOffice: React.FC = () => {
           </div>
         </Card>
       </div>
-    </div>
+    </PageContainer>
   );
 };

--- a/src/components/apps/Portal.tsx
+++ b/src/components/apps/Portal.tsx
@@ -4,6 +4,7 @@ import { motion } from 'framer-motion';
 import { gsap } from 'gsap';
 import * as LucideIcons from 'lucide-react';
 import { MotionWrapper } from '../ui/MotionWrapper';
+import { PageContainer } from '../layout/PageContainer';
 import { useAuthStore } from '../../stores/authStore';
 import { getAvailableApps } from '../../config/apps';
 import { theme } from '../../config/theme';
@@ -46,8 +47,8 @@ export const Portal: React.FC = () => {
   };
 
   return (
-    <MotionWrapper type="page" className="p-6">
-      <div className="max-w-7xl mx-auto">
+    <MotionWrapper type="page">
+      <PageContainer>
         <div className="mb-8">
           <h2 className="text-3xl font-bold mb-2">Welcome back, {user?.name}</h2>
           <p className="text-muted">
@@ -145,7 +146,7 @@ export const Portal: React.FC = () => {
             </div>
           </Card>
         </div>
-      </div>
+      </PageContainer>
     </MotionWrapper>
   );
 };

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -25,7 +25,7 @@ export const AppShell: React.FC = () => {
   const shouldRenderPaper = paperShader.enabled && paperShader.surfaces.includes('background');
 
   return (
-    <div className="min-h-screen bg-bg-dust text-ink relative">
+    <div className="flex flex-col min-h-screen bg-bg-dust text-ink relative">
       {shouldRenderPaper && (
         <PaperShader
           intensity={paperShader.intensity}
@@ -86,7 +86,7 @@ export const AppShell: React.FC = () => {
         </div>
       </header>
 
-      <main className="relative z-10">
+      <main className="relative z-10 flex-1 w-full">
         <PageTransition>
           <Outlet />
         </PageTransition>

--- a/src/components/layout/PageContainer.tsx
+++ b/src/components/layout/PageContainer.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { cn } from '@mas/utils';
+
+type PageContainerProps = React.HTMLAttributes<HTMLDivElement>;
+
+export const PageContainer: React.FC<PageContainerProps> = ({ className, children, ...props }) => {
+  return (
+    <div
+      className={cn('max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6', className)}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- update the AppShell wrapper to use a flex column layout so the main content grows to fill the viewport
- introduce a reusable PageContainer component to centralize responsive gutters
- wrap the portal and backoffice entry points with the new container and document the layout update in agents.md

## Testing
- npm run lint *(fails: existing lint errors in POS.tsx, Portal.tsx, PaperShader.tsx, StatusIndicator.tsx, and themeStore.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68d003c48a5c8326ab8237a91accf220