### PR TITLE
Add multi-tender checkout payment flows

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -125,3 +125,15 @@
 - Log any issues needing backend fixes.  
 **Status:** TODO  
 **Log:**  
+
+---
+
+## Agent 26 — Tendering
+**Scope:** Checkout tender workflows, multi-method payments, and tender validation.
+**Tasks:**
+- Add support for recording multiple tender types at checkout.
+- Validate tender balances before queuing orders.
+- Surface tender references and idempotency keys in payloads.
+**Status:** DONE
+**Log:**
+- 2025-09-21: Implemented cash/card/wallet tender modals with balance validation, added tender breakdown and idempotency keys to queued orders. Tests: `npm run lint` (fails due to pre-existing lint errors outside scope).


### PR DESCRIPTION
## Summary
- implement multi-tender payment management in the POS checkout with validation and enhanced offline order payloads
- add checkout footer tender list plus modal forms for cash, card, and wallet entries
- document Agent 26 tendering work and lint check outcome in the task board

## Testing
- npm run lint *(fails: existing lint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cffb4373988326aa81b30f3372299a