### PR TITLE
feat: add telemetry client and incident visibility

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -118,10 +118,23 @@
 ---
 
 ## Agent 10 — Database/Functionality Checks
-**Scope:** Ensure functional logic and DB integration still work after UI changes.  
-**Tasks:**  
-- Verify forms still submit correctly.  
-- Confirm API/data fetching unaffected.  
-- Log any issues needing backend fixes.  
-**Status:** TODO  
-**Log:**  
+**Scope:** Ensure functional logic and DB integration still work after UI changes.
+**Tasks:**
+- Verify forms still submit correctly.
+- Confirm API/data fetching unaffected.
+- Log any issues needing backend fixes.
+**Status:** TODO
+**Log:**
+
+---
+
+## Agent 24 — Telemetry
+**Scope:** Telemetry ingestion, status surfacing, shared observability UI.
+**Tasks:**
+- Build telemetry client for incidents and health alerts.
+- Surface telemetry issues through StatusIndicator banners/tooltips.
+- Provide BackOffice with a reusable incident log.
+- Document telemetry handling updates here.
+**Status:** DONE
+**Log:**
+- Added a persisted telemetry store with incident/health helpers and exposed a lightweight telemetry client for downstream use. Linked the data to StatusIndicator for accessible alerts with severity tooltips and added a reusable TelemetryLog for BackOffice. Lint check reports pre-existing project warnings/errors (Portal hook deps, POS unused types, PaperShader escapes, theme store params); no new violations introduced by telemetry changes.

--- a/src/components/apps/BackOffice.tsx
+++ b/src/components/apps/BackOffice.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Card, Button } from '@mas/ui';
 import { useTheme } from '../../stores/themeStore';
+import { TelemetryLog } from '../telemetry/TelemetryLog';
 
 const themeModes = [
   { id: 'light', label: 'Light' },
@@ -132,6 +133,18 @@ export const BackOffice: React.FC = () => {
             </div>
           </Card>
         </div>
+
+        <Card className="space-y-4">
+          <div>
+            <h2 className="text-xl font-semibold">Telemetry &amp; Incident Feed</h2>
+            <p className="text-muted text-sm">
+              Review live incidents, acknowledgements, and health alerts surfaced by the telemetry client across
+              MAS services.
+            </p>
+          </div>
+
+          <TelemetryLog limit={6} />
+        </Card>
 
         <Card className="space-y-4">
           <h2 className="text-xl font-semibold">Live Preview</h2>

--- a/src/components/telemetry/TelemetryLog.tsx
+++ b/src/components/telemetry/TelemetryLog.tsx
@@ -1,0 +1,296 @@
+import React from 'react';
+import { formatDistanceToNowStrict } from 'date-fns';
+import { Activity, AlertCircle, CheckCircle2 } from 'lucide-react';
+import { Button } from '@mas/ui';
+import { cn } from '@mas/utils';
+import { shallow } from 'zustand/shallow';
+import { useTelemetryStore } from '../../stores/telemetryStore';
+import {
+  TELEMETRY_SEVERITY_ORDER,
+  getIncidentStatusLabel,
+  getSeverityLabel,
+  isIncidentActive
+} from '../../utils/telemetry';
+import { TelemetryEvent, TelemetryIncident, TelemetrySeverity } from '../../types';
+
+interface TelemetryLogProps {
+  limit?: number;
+  showHealth?: boolean;
+  className?: string;
+}
+
+const severityBadgeClasses: Record<TelemetrySeverity, string> = {
+  critical: 'bg-[#EE766D] text-white',
+  warning:
+    'bg-[rgba(238,118,109,0.12)] text-[#24242E] border border-[rgba(238,118,109,0.25)]',
+  info: 'bg-[rgba(214,214,214,0.5)] text-[#24242E] border border-[rgba(36,36,46,0.18)]'
+};
+
+const statusBadgeClasses: Record<TelemetryIncident['status'], string> = {
+  open: 'border border-dashed border-[#24242E] text-[#24242E]',
+  acknowledged: 'bg-[rgba(214,214,214,0.5)] border border-[rgba(36,36,46,0.18)] text-[#24242E]',
+  resolved: 'bg-[#D6D6D6] border border-[rgba(36,36,46,0.12)] text-[#24242E]'
+};
+
+const iconWrapperClasses: Record<'incident' | 'health', string> = {
+  incident:
+    'bg-[rgba(238,118,109,0.12)] text-[#EE766D] border border-[rgba(238,118,109,0.3)] shadow-[0_8px_18px_rgba(238,118,109,0.08)]',
+  health: 'bg-[rgba(214,214,214,0.4)] text-[#24242E] border border-[rgba(36,36,46,0.2)]'
+};
+
+const incidentStatusWeight: Record<TelemetryIncident['status'], number> = {
+  open: 3,
+  acknowledged: 2,
+  resolved: 1
+};
+
+const sortEvents = (a: TelemetryEvent, b: TelemetryEvent) => {
+  if (a.kind === 'incident' && b.kind === 'incident') {
+    const statusDelta = incidentStatusWeight[b.status] - incidentStatusWeight[a.status];
+    if (statusDelta !== 0) {
+      return statusDelta;
+    }
+
+    const severityDelta = TELEMETRY_SEVERITY_ORDER[b.severity] - TELEMETRY_SEVERITY_ORDER[a.severity];
+    if (severityDelta !== 0) {
+      return severityDelta;
+    }
+  } else if (a.kind === 'incident') {
+    return -1;
+  } else if (b.kind === 'incident') {
+    return 1;
+  }
+
+  return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+};
+
+export const TelemetryLog: React.FC<TelemetryLogProps> = ({
+  limit = 8,
+  showHealth = true,
+  className
+}) => {
+  const telemetry = useTelemetryStore(
+    (state) => ({
+      events: state.events,
+      acknowledgeIncident: state.acknowledgeIncident,
+      resolveIncident: state.resolveIncident
+    }),
+    shallow
+  );
+
+  const activeCount = React.useMemo(
+    () =>
+      telemetry.events.filter(
+        (event): event is TelemetryIncident => event.kind === 'incident' && isIncidentActive(event)
+      ).length,
+    [telemetry.events]
+  );
+
+  const resolvedCount = React.useMemo(
+    () =>
+      telemetry.events.filter(
+        (event): event is TelemetryIncident => event.kind === 'incident' && event.status === 'resolved'
+      ).length,
+    [telemetry.events]
+  );
+
+  const entries = React.useMemo(() => {
+    const base = showHealth ? telemetry.events : telemetry.events.filter((event) => event.kind === 'incident');
+    const sorted = [...base].sort(sortEvents);
+    return limit ? sorted.slice(0, limit) : sorted;
+  }, [telemetry.events, limit, showHealth]);
+
+  const latestEntry = entries[0];
+
+  const renderIncident = (incident: TelemetryIncident) => {
+    return (
+      <article
+        key={incident.id}
+        className="rounded-xl border border-[rgba(36,36,46,0.14)] bg-surface-100/80 p-4 shadow-[0_6px_18px_rgba(36,36,46,0.06)]"
+      >
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="flex items-start gap-3">
+            <span
+              className={cn(
+                'flex h-10 w-10 items-center justify-center rounded-full border text-sm font-semibold',
+                iconWrapperClasses.incident
+              )}
+            >
+              <AlertCircle size={18} />
+            </span>
+            <div className="space-y-1">
+              <p className="font-semibold text-ink">{incident.message}</p>
+              <p className="text-xs text-muted">
+                {formatDistanceToNowStrict(new Date(incident.createdAt), { addSuffix: true })}
+                {incident.source ? ` • ${incident.source}` : ''}
+              </p>
+            </div>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-2">
+            <span
+              className={cn(
+                'inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-[11px] font-semibold uppercase tracking-wide',
+                severityBadgeClasses[incident.severity]
+              )}
+            >
+              {getSeverityLabel(incident.severity)}
+            </span>
+            <span
+              className={cn(
+                'inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-[11px] font-medium uppercase tracking-wide',
+                statusBadgeClasses[incident.status]
+              )}
+            >
+              {getIncidentStatusLabel(incident.status)}
+            </span>
+          </div>
+        </div>
+
+        {incident.detail && <p className="mt-3 text-sm text-muted">{incident.detail}</p>}
+
+        {incident.resolutionNote && (
+          <p className="mt-2 text-xs text-[#24242E]/70">
+            <span className="font-semibold">Resolution:</span> {incident.resolutionNote}
+          </p>
+        )}
+
+        <div className="mt-3 flex flex-wrap items-center gap-3 text-[11px] text-[#24242E]/65">
+          {incident.acknowledgedAt && (
+            <span>
+              Acknowledged{' '}
+              {formatDistanceToNowStrict(new Date(incident.acknowledgedAt), { addSuffix: true })}
+            </span>
+          )}
+          {incident.resolvedAt && (
+            <span>
+              Resolved {formatDistanceToNowStrict(new Date(incident.resolvedAt), { addSuffix: true })}
+            </span>
+          )}
+        </div>
+
+        {incident.status !== 'resolved' && (
+          <div className="mt-4 flex flex-wrap gap-2">
+            {incident.status === 'open' && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => telemetry.acknowledgeIncident(incident.id)}
+              >
+                Acknowledge
+              </Button>
+            )}
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => telemetry.resolveIncident(incident.id)}
+            >
+              Resolve
+            </Button>
+          </div>
+        )}
+      </article>
+    );
+  };
+
+  const renderHealth = (alert: TelemetryEvent) => {
+    if (alert.kind !== 'health') {
+      return null;
+    }
+
+    return (
+      <article
+        key={alert.id}
+        className="rounded-xl border border-[rgba(36,36,46,0.12)] bg-surface-100/70 p-4"
+      >
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="flex items-start gap-3">
+            <span
+              className={cn(
+                'flex h-10 w-10 items-center justify-center rounded-full border text-sm font-semibold',
+                iconWrapperClasses.health
+              )}
+            >
+              <Activity size={18} />
+            </span>
+            <div className="space-y-1">
+              <p className="font-semibold text-ink">{alert.message}</p>
+              <p className="text-xs text-muted">
+                {formatDistanceToNowStrict(new Date(alert.createdAt), { addSuffix: true })}
+                {alert.source ? ` • ${alert.source}` : ''}
+              </p>
+            </div>
+          </div>
+
+          <span
+            className={cn(
+              'inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-[11px] font-semibold uppercase tracking-wide',
+              severityBadgeClasses[alert.severity]
+            )}
+          >
+            {getSeverityLabel(alert.severity)}
+          </span>
+        </div>
+
+        {alert.detail && <p className="mt-3 text-sm text-muted">{alert.detail}</p>}
+
+        {alert.metrics && (
+          <div className="mt-3 grid grid-cols-1 gap-2 text-xs text-[#24242E]/75 sm:grid-cols-2">
+            {Object.entries(alert.metrics as Record<string, number>).map(([key, value]) => (
+              <div
+                key={key}
+                className="flex items-center justify-between gap-3 rounded-lg border border-[rgba(36,36,46,0.12)] bg-surface-100/80 px-3 py-2"
+              >
+                <span className="text-[11px] uppercase tracking-wide text-[#24242E]/60">{key}</span>
+                <span className="font-medium text-ink">{value.toLocaleString()}</span>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {typeof alert.durationMs === 'number' && (
+          <p className="mt-3 text-xs text-[#24242E]/65">
+            Duration {Math.round(alert.durationMs / 1000)}s
+          </p>
+        )}
+      </article>
+    );
+  };
+
+  return (
+    <section className={cn('space-y-4', className)} aria-live="polite">
+      <header className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <p className="text-sm font-semibold text-ink">Telemetry stream</p>
+          <p className="text-xs text-muted">
+            {entries.length > 0 && latestEntry
+              ? `Updated ${formatDistanceToNowStrict(new Date(latestEntry.createdAt), {
+                  addSuffix: true
+                })}`
+              : 'No signals yet'}
+          </p>
+        </div>
+        <div className="flex items-center gap-2 text-xs text-[#24242E]/70">
+          <span className="inline-flex items-center gap-1 rounded-full bg-[#EE766D] px-2.5 py-1 text-white">
+            <AlertCircle size={14} /> {activeCount} active
+          </span>
+          <span className="inline-flex items-center gap-1 rounded-full border border-[rgba(36,36,46,0.2)] px-2.5 py-1 text-[#24242E]/75">
+            <CheckCircle2 size={14} /> {resolvedCount} resolved
+          </span>
+        </div>
+      </header>
+
+      {entries.length === 0 ? (
+        <div className="rounded-xl border border-dashed border-[#D6D6D6] bg-surface-100 p-6 text-center text-sm text-muted">
+          No incidents or health alerts recorded yet. Telemetry updates will appear here instantly.
+        </div>
+      ) : (
+        <div className="space-y-4">
+          {entries.map((event) =>
+            event.kind === 'incident' ? renderIncident(event) : renderHealth(event)
+          )}
+        </div>
+      )}
+    </section>
+  );
+};

--- a/src/components/ui/StatusIndicator.tsx
+++ b/src/components/ui/StatusIndicator.tsx
@@ -1,59 +1,376 @@
 import React from 'react';
-import { motion } from 'framer-motion';
-import { Wifi, WifiOff, Clock, CheckCircle, AlertCircle } from 'lucide-react';
+import { AnimatePresence, motion } from 'framer-motion';
+import { formatDistanceToNowStrict } from 'date-fns';
+import { Activity, AlertCircle, CheckCircle, Clock, WifiOff } from 'lucide-react';
+import { shallow } from 'zustand/shallow';
 import { useAuthStore } from '../../stores/authStore';
 import { useOfflineStore } from '../../stores/offlineStore';
+import { useTelemetryStore } from '../../stores/telemetryStore';
+import {
+  getIncidentStatusLabel,
+  getSeverityLabel,
+  isIncidentActive,
+  sortIncidents
+} from '../../utils/telemetry';
+import { TelemetryHealthAlert, TelemetryIncident } from '../../types';
+
+type StatusType = 'offline' | 'syncing' | 'incident' | 'health' | 'online';
+
+interface StatusConfig {
+  type: StatusType;
+  icon: React.ComponentType<{ size?: number }>;
+  label: string;
+  message: string;
+  classes: string;
+  pulse: boolean;
+  severity?: TelemetryIncident['severity'];
+  tooltipIncidents?: TelemetryIncident[];
+  healthAlert?: TelemetryHealthAlert | null;
+}
+
+const severityClasses: Record<'critical' | 'warning' | 'info', string> = {
+  critical:
+    'text-[#EE766D] bg-[rgba(238,118,109,0.16)] border border-[rgba(238,118,109,0.45)] shadow-[0_10px_30px_rgba(238,118,109,0.12)]',
+  warning: 'text-[#EE766D] bg-[rgba(238,118,109,0.08)] border border-[rgba(238,118,109,0.25)]',
+  info: 'text-[#24242E] bg-[rgba(214,214,214,0.55)] border border-[rgba(36,36,46,0.18)]'
+};
+
+const offlineClasses =
+  'text-[#24242E] bg-[rgba(36,36,46,0.12)] border border-[rgba(36,36,46,0.22)]';
+const syncingClasses =
+  'text-[#24242E] bg-[rgba(214,214,214,0.4)] border border-[rgba(36,36,46,0.2)]';
+const onlineClasses =
+  'text-[#24242E] bg-[rgba(214,214,214,0.3)] border border-[rgba(36,36,46,0.18)]';
+
+const indicatorBaseClasses =
+  'relative flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium border transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#EE766D]/40';
 
 export const StatusIndicator: React.FC = () => {
   const { isOnline } = useAuthStore();
   const { queuedOrders } = useOfflineStore();
+  const telemetryState = useTelemetryStore(
+    (state) => ({
+      events: state.events,
+      activeIncidentId: state.activeIncidentId,
+      lastHealthCheck: state.lastHealthCheck
+    }),
+    shallow
+  );
 
-  const getStatus = () => {
-    if (!isOnline) {
-      return {
-        icon: WifiOff,
-        text: queuedOrders.length > 0 ? `Offline - ${queuedOrders.length} Queued` : 'Offline',
-        color: 'text-warning bg-warning/10',
-        pulse: true
-      };
-    }
-    
-    if (queuedOrders.length > 0) {
-      return {
-        icon: Clock,
-        text: `Syncing - ${queuedOrders.length}`,
-        color: 'text-primary-600 bg-primary-100',
-        pulse: true
-      };
+  const openIncidents = React.useMemo(
+    () =>
+      telemetryState.events.filter(
+        (event): event is TelemetryIncident =>
+          event.kind === 'incident' && isIncidentActive(event)
+      ),
+    [telemetryState.events]
+  );
+
+  const sortedOpenIncidents = React.useMemo(
+    () => sortIncidents(openIncidents),
+    [openIncidents]
+  );
+
+  const activeIncident = React.useMemo(() => {
+    if (sortedOpenIncidents.length === 0) {
+      return null;
     }
 
-    return {
-      icon: CheckCircle,
-      text: 'Online',
-      color: 'text-success bg-success/10',
-      pulse: false
+    if (!telemetryState.activeIncidentId) {
+      return sortedOpenIncidents[0];
+    }
+
+    return (
+      sortedOpenIncidents.find(
+        (incident) => incident.id === telemetryState.activeIncidentId
+      ) ?? sortedOpenIncidents[0]
+    );
+  }, [sortedOpenIncidents, telemetryState.activeIncidentId]);
+
+  const healthAlert = React.useMemo(() => {
+    const alert = telemetryState.lastHealthCheck;
+    if (!alert || alert.severity === 'info') {
+      return null;
+    }
+    return alert;
+  }, [telemetryState.lastHealthCheck]);
+
+  const queuedCount = queuedOrders.length;
+  const openIncidentCount = openIncidents.length;
+  const tooltipIncidents = React.useMemo(
+    () => sortedOpenIncidents.slice(0, 3),
+    [sortedOpenIncidents]
+  );
+
+  const [isTooltipOpen, setTooltipOpen] = React.useState(false);
+  const tooltipId = React.useId();
+
+  React.useEffect(() => {
+    if (!activeIncident && !healthAlert) {
+      setTooltipOpen(false);
+    }
+  }, [activeIncident, healthAlert]);
+
+  let status: StatusConfig;
+
+  if (!isOnline) {
+    const text = queuedCount > 0 ? `Offline · ${queuedCount} queued` : 'Offline';
+    status = {
+      type: 'offline',
+      icon: WifiOff,
+      label: 'Offline',
+      message: text,
+      classes: offlineClasses,
+      pulse: true
     };
+  } else if (queuedCount > 0) {
+    status = {
+      type: 'syncing',
+      icon: Clock,
+      label: 'Syncing',
+      message: `${queuedCount} queued`,
+      classes: syncingClasses,
+      pulse: true
+    };
+  } else if (activeIncident) {
+    status = {
+      type: 'incident',
+      icon: AlertCircle,
+      label: `${getSeverityLabel(activeIncident.severity)} incident`,
+      message: activeIncident.message,
+      classes: severityClasses[activeIncident.severity],
+      pulse: true,
+      severity: activeIncident.severity,
+      tooltipIncidents,
+      healthAlert: null
+    };
+  } else if (healthAlert) {
+    status = {
+      type: 'health',
+      icon: Activity,
+      label: `${getSeverityLabel(healthAlert.severity)} health`,
+      message: healthAlert.message,
+      classes: severityClasses[healthAlert.severity],
+      pulse: false,
+      severity: healthAlert.severity,
+      tooltipIncidents: [],
+      healthAlert
+    };
+  } else {
+    status = {
+      type: 'online',
+      icon: CheckCircle,
+      label: 'Operational',
+      message: 'Systems nominal',
+      classes: onlineClasses,
+      pulse: false,
+      tooltipIncidents: [],
+      healthAlert: null
+    };
+  }
+
+  const Icon = status.icon;
+  const isInteractive = status.type === 'incident' || status.type === 'health';
+
+  const ariaLabel = `${status.label}. ${status.message}`;
+
+  const toggleTooltip = () => {
+    if (!isInteractive) {
+      return;
+    }
+    setTooltipOpen((previous) => !previous);
   };
 
-  const status = getStatus();
-  const Icon = status.icon;
+  const openTooltip = () => {
+    if (isInteractive) {
+      setTooltipOpen(true);
+    }
+  };
 
-  return (
-    <motion.div
-      initial={{ opacity: 0, scale: 0.9 }}
-      animate={{ opacity: 1, scale: 1 }}
-      className={`
-        flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium
-        ${status.color}
-      `}
-    >
-      <motion.div
-        animate={status.pulse ? { scale: [1, 1.1, 1] } : {}}
-        transition={{ duration: 2, repeat: Infinity }}
-      >
+  const closeTooltip = () => {
+    if (isInteractive) {
+      setTooltipOpen(false);
+    }
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
+    if (event.key === 'Escape') {
+      event.stopPropagation();
+      closeTooltip();
+      event.currentTarget.blur();
+    }
+  };
+
+  const iconMotion = {
+    animate: status.pulse ? { scale: [1, 1.08, 1] } : {},
+    transition: { duration: 2, repeat: Infinity }
+  } as const;
+
+  const renderContent = (
+    <>
+      <motion.div {...iconMotion}>
         <Icon size={14} />
       </motion.div>
-      <span className="hidden sm:block">{status.text}</span>
-    </motion.div>
+      <span className="hidden sm:inline text-sm font-medium">{status.label}</span>
+      {(status.type === 'offline' || status.type === 'syncing') && (
+        <span className="hidden md:inline text-xs text-[#24242E]/70">{status.message}</span>
+      )}
+      {status.type === 'incident' && (
+        <>
+          <span className="hidden md:inline max-w-[200px] truncate text-xs text-[#24242E]/80">
+            {status.message}
+          </span>
+          {openIncidentCount > 1 && (
+            <span className="hidden sm:inline-flex h-5 min-w-[20px] items-center justify-center rounded-full bg-[#EE766D] px-1.5 text-[11px] font-semibold text-white">
+              {openIncidentCount}
+            </span>
+          )}
+        </>
+      )}
+      {status.type === 'health' && (
+        <span className="hidden md:inline max-w-[200px] truncate text-xs text-[#24242E]/75">
+          {status.message}
+        </span>
+      )}
+    </>
+  );
+
+  return (
+    <div className="relative" role="status" aria-live="polite">
+      {isInteractive ? (
+        <>
+          <motion.button
+            type="button"
+            initial={{ opacity: 0, scale: 0.92 }}
+            animate={{ opacity: 1, scale: 1 }}
+            whileTap={{ scale: 0.97 }}
+            onMouseEnter={openTooltip}
+            onFocus={openTooltip}
+            onMouseLeave={closeTooltip}
+            onBlur={closeTooltip}
+            onClick={toggleTooltip}
+            onKeyDown={handleKeyDown}
+            aria-label={ariaLabel}
+            aria-expanded={isTooltipOpen}
+            aria-controls={isTooltipOpen ? tooltipId : undefined}
+            aria-describedby={isTooltipOpen ? tooltipId : undefined}
+            className={`${indicatorBaseClasses} ${status.classes}`}
+          >
+            {renderContent}
+          </motion.button>
+          <AnimatePresence>
+            {isTooltipOpen && (
+              <motion.div
+                key="status-tooltip"
+                id={tooltipId}
+                role="tooltip"
+                initial={{ opacity: 0, y: -6 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: -6 }}
+                transition={{ duration: 0.18 }}
+                onMouseEnter={openTooltip}
+                onMouseLeave={closeTooltip}
+                className="absolute right-0 z-50 mt-2 w-80 rounded-xl border border-[rgba(36,36,46,0.16)] bg-surface-100/95 p-4 text-left shadow-card backdrop-blur-sm"
+              >
+                {status.type === 'incident' && status.tooltipIncidents && (
+                  <div className="space-y-3">
+                    <div className="flex items-center justify-between">
+                      <p className="text-sm font-semibold text-ink">Active incidents</p>
+                      <span className="text-xs font-medium uppercase tracking-wide text-[#24242E]/60">
+                        {getSeverityLabel(status.severity ?? 'info')}
+                      </span>
+                    </div>
+                    <ul className="space-y-2">
+                      {status.tooltipIncidents.map((incident) => (
+                        <li
+                          key={incident.id}
+                          className="rounded-lg border border-[rgba(36,36,46,0.14)] bg-surface-100/80 p-3"
+                        >
+                          <p className="text-sm font-medium text-ink">{incident.message}</p>
+                          {incident.source && (
+                            <p className="mt-1 text-[11px] font-medium uppercase tracking-wide text-[#24242E]/55">
+                              {incident.source}
+                            </p>
+                          )}
+                          {incident.detail && (
+                            <p className="mt-1 text-xs text-muted">{incident.detail}</p>
+                          )}
+                          <div className="mt-2 flex items-center justify-between text-[11px] text-[#24242E]/65">
+                            <span>{getIncidentStatusLabel(incident.status)}</span>
+                            <span>
+                              {formatDistanceToNowStrict(new Date(incident.createdAt), {
+                                addSuffix: true
+                              })}
+                            </span>
+                          </div>
+                        </li>
+                      ))}
+                    </ul>
+                    {openIncidentCount > (status.tooltipIncidents?.length ?? 0) && (
+                      <p className="text-xs text-[#24242E]/60">
+                        +{openIncidentCount - (status.tooltipIncidents?.length ?? 0)} additional incidents tracked
+                      </p>
+                    )}
+                  </div>
+                )}
+
+                {status.type === 'health' && status.healthAlert && (
+                  <div className="space-y-3">
+                    <div className="flex items-center justify-between">
+                      <p className="text-sm font-semibold text-ink">Service health</p>
+                      <span className="text-xs font-medium uppercase tracking-wide text-[#24242E]/60">
+                        {getSeverityLabel(status.healthAlert.severity)}
+                      </span>
+                    </div>
+                    {status.healthAlert.source && (
+                      <p className="text-[11px] font-medium uppercase tracking-wide text-[#24242E]/55">
+                        {status.healthAlert.source}
+                      </p>
+                    )}
+                    {status.healthAlert.detail && (
+                      <p className="text-sm text-muted">{status.healthAlert.detail}</p>
+                    )}
+                    <p className="text-xs text-[#24242E]/70">
+                      Updated {formatDistanceToNowStrict(new Date(status.healthAlert.createdAt), {
+                        addSuffix: true
+                      })}
+                    </p>
+                    {status.healthAlert.metrics && (
+                      <div className="rounded-lg border border-[rgba(36,36,46,0.14)] bg-surface-100/80 p-3">
+                        <p className="text-xs font-semibold uppercase tracking-wide text-[#24242E]/60">
+                          Metrics
+                        </p>
+                        <dl className="mt-2 grid grid-cols-1 gap-2 text-xs text-[#24242E]/75">
+                          {Object.entries(status.healthAlert.metrics as Record<string, number>).map(([key, value]) => (
+                            <div key={key} className="flex items-center justify-between gap-4">
+                              <dt className="capitalize text-[11px] text-[#24242E]/65">{key}</dt>
+                              <dd className="font-medium text-ink">{value.toLocaleString()}</dd>
+                            </div>
+                          ))}
+                        </dl>
+                      </div>
+                    )}
+                    {typeof status.healthAlert.durationMs === 'number' && (
+                      <p className="text-xs text-[#24242E]/70">
+                        Duration {Math.round(status.healthAlert.durationMs / 1000)}s
+                      </p>
+                    )}
+                  </div>
+                )}
+              </motion.div>
+            )}
+          </AnimatePresence>
+        </>
+      ) : (
+        <motion.div
+          initial={{ opacity: 0, scale: 0.92 }}
+          animate={{ opacity: 1, scale: 1 }}
+          className={`${indicatorBaseClasses} ${status.classes}`}
+          aria-label={ariaLabel}
+        >
+          {renderContent}
+        </motion.div>
+      )}
+    </div>
   );
 };

--- a/src/stores/telemetryStore.ts
+++ b/src/stores/telemetryStore.ts
@@ -1,0 +1,236 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import { v4 as uuid } from 'uuid';
+import {
+  HealthPayload,
+  IncidentPayload,
+  TelemetryEvent,
+  TelemetryHealthAlert,
+  TelemetryIncident
+} from '../types';
+import { isIncidentActive, sortIncidents } from '../utils/telemetry';
+
+const MAX_EVENT_HISTORY = 50;
+
+const clampEvents = (events: TelemetryEvent[]) => events.slice(0, MAX_EVENT_HISTORY);
+
+const computeActiveIncidentId = (events: TelemetryEvent[]) => {
+  const incidents = events.filter(
+    (event): event is TelemetryIncident => event.kind === 'incident' && isIncidentActive(event)
+  );
+
+  if (incidents.length === 0) {
+    return null;
+  }
+
+  const [topIncident] = sortIncidents(incidents);
+  return topIncident?.id ?? null;
+};
+
+interface TelemetryState {
+  events: TelemetryEvent[];
+  lastHealthCheck: TelemetryHealthAlert | null;
+  activeIncidentId: string | null;
+
+  reportIncident: (payload: IncidentPayload) => TelemetryIncident;
+  reportHealth: (payload: HealthPayload) => TelemetryHealthAlert;
+  acknowledgeIncident: (incidentId: string) => void;
+  resolveIncident: (incidentId: string, note?: string) => TelemetryIncident | null;
+  clearResolved: () => void;
+  getActiveIncident: () => TelemetryIncident | null;
+  getOpenIncidents: (limit?: number) => TelemetryIncident[];
+}
+
+export const useTelemetryStore = create<TelemetryState>()(
+  persist(
+    (set, get) => ({
+      events: [],
+      lastHealthCheck: null,
+      activeIncidentId: null,
+
+      reportIncident: (payload) => {
+        let createdIncident: TelemetryIncident | null = null;
+
+        set((state) => {
+          const timestamp = new Date().toISOString();
+          const status = payload.status ?? 'open';
+
+          createdIncident = {
+            id: uuid(),
+            kind: 'incident',
+            severity: payload.severity,
+            message: payload.message,
+            detail: payload.detail,
+            source: payload.source,
+            context: payload.context,
+            createdAt: timestamp,
+            status,
+            resolutionNote: payload.resolutionNote,
+            acknowledgedAt:
+              status === 'acknowledged' || status === 'resolved' ? timestamp : undefined,
+            resolvedAt: status === 'resolved' ? timestamp : undefined
+          };
+
+          const events = clampEvents([createdIncident!, ...state.events]);
+
+          return {
+            events,
+            activeIncidentId: computeActiveIncidentId(events)
+          };
+        });
+
+        return createdIncident!;
+      },
+
+      reportHealth: (payload) => {
+        let createdHealth: TelemetryHealthAlert | null = null;
+
+        set((state) => {
+          createdHealth = {
+            id: uuid(),
+            kind: 'health',
+            severity: payload.severity,
+            message: payload.message,
+            detail: payload.detail,
+            source: payload.source,
+            context: payload.context,
+            metrics: payload.metrics,
+            durationMs: payload.durationMs,
+            createdAt: new Date().toISOString()
+          };
+
+          const events = clampEvents([createdHealth!, ...state.events]);
+
+          return {
+            events,
+            lastHealthCheck: createdHealth!,
+            activeIncidentId: computeActiveIncidentId(events)
+          };
+        });
+
+        return createdHealth!;
+      },
+
+      acknowledgeIncident: (incidentId) => {
+        set((state) => {
+          let updated = false;
+
+          const events = state.events.map((event) => {
+            if (event.kind === 'incident' && event.id === incidentId && event.status === 'open') {
+              updated = true;
+              return {
+                ...event,
+                status: 'acknowledged',
+                acknowledgedAt: new Date().toISOString()
+              } satisfies TelemetryIncident;
+            }
+
+            return event;
+          });
+
+          if (!updated) {
+            return state;
+          }
+
+          return {
+            events,
+            activeIncidentId: computeActiveIncidentId(events)
+          };
+        });
+      },
+
+      resolveIncident: (incidentId, note) => {
+        let resolvedIncident: TelemetryIncident | null = null;
+
+        set((state) => {
+          let changed = false;
+
+          const events = state.events.map((event) => {
+            if (event.kind === 'incident' && event.id === incidentId && event.status !== 'resolved') {
+              changed = true;
+              const resolvedAt = new Date().toISOString();
+
+              resolvedIncident = {
+                ...event,
+                status: 'resolved',
+                resolvedAt,
+                acknowledgedAt: event.acknowledgedAt ?? resolvedAt,
+                resolutionNote: note ?? event.resolutionNote
+              } satisfies TelemetryIncident;
+
+              return resolvedIncident;
+            }
+
+            return event;
+          });
+
+          if (!changed) {
+            return state;
+          }
+
+          return {
+            events,
+            activeIncidentId: computeActiveIncidentId(events)
+          };
+        });
+
+        return resolvedIncident;
+      },
+
+      clearResolved: () => {
+        set((state) => {
+          const events = state.events.filter(
+            (event) => event.kind !== 'incident' || event.status !== 'resolved'
+          );
+
+          return {
+            events,
+            activeIncidentId: computeActiveIncidentId(events)
+          };
+        });
+      },
+
+      getActiveIncident: () => {
+        const { events, activeIncidentId } = get();
+        if (!activeIncidentId) {
+          return null;
+        }
+
+        const incident = events.find(
+          (event): event is TelemetryIncident => event.kind === 'incident' && event.id === activeIncidentId
+        );
+
+        if (incident) {
+          return incident;
+        }
+
+        const fallback = sortIncidents(
+          events.filter(
+            (event): event is TelemetryIncident => event.kind === 'incident' && isIncidentActive(event)
+          )
+        );
+
+        return fallback[0] ?? null;
+      },
+
+      getOpenIncidents: (limit) => {
+        const { events } = get();
+        const open = sortIncidents(
+          events.filter(
+            (event): event is TelemetryIncident => event.kind === 'incident' && isIncidentActive(event)
+          )
+        );
+
+        return typeof limit === 'number' ? open.slice(0, limit) : open;
+      }
+    }),
+    {
+      name: 'mas-telemetry-store',
+      partialize: (state) => ({
+        events: state.events,
+        lastHealthCheck: state.lastHealthCheck,
+        activeIncidentId: state.activeIncidentId
+      })
+    }
+  )
+);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -189,3 +189,53 @@ export interface MotionPresets {
     duration: number;
   };
 }
+
+// Telemetry & incidents
+export type TelemetrySeverity = 'info' | 'warning' | 'critical';
+
+export interface TelemetryEventBase {
+  id: string;
+  kind: 'incident' | 'health';
+  severity: TelemetrySeverity;
+  message: string;
+  detail?: string;
+  source?: string;
+  context?: Record<string, unknown>;
+  createdAt: string;
+}
+
+export interface TelemetryIncident extends TelemetryEventBase {
+  kind: 'incident';
+  status: 'open' | 'acknowledged' | 'resolved';
+  acknowledgedAt?: string;
+  resolvedAt?: string;
+  resolutionNote?: string;
+}
+
+export interface TelemetryHealthAlert extends TelemetryEventBase {
+  kind: 'health';
+  metrics?: Record<string, number>;
+  durationMs?: number;
+}
+
+export type TelemetryEvent = TelemetryIncident | TelemetryHealthAlert;
+
+export interface IncidentPayload {
+  severity: TelemetrySeverity;
+  message: string;
+  detail?: string;
+  source?: string;
+  context?: Record<string, unknown>;
+  status?: TelemetryIncident['status'];
+  resolutionNote?: string;
+}
+
+export interface HealthPayload {
+  severity: TelemetrySeverity;
+  message: string;
+  detail?: string;
+  source?: string;
+  context?: Record<string, unknown>;
+  metrics?: Record<string, number>;
+  durationMs?: number;
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,1 +1,3 @@
 export * from './cn';
+export * from './telemetry';
+export * from './telemetryClient';

--- a/src/utils/telemetry.ts
+++ b/src/utils/telemetry.ts
@@ -1,0 +1,52 @@
+import { TelemetryIncident, TelemetrySeverity } from '../types';
+
+export const TELEMETRY_PALETTE = Object.freeze({
+  accent: '#EE766D',
+  base: '#24242E',
+  neutral: '#D6D6D6'
+});
+
+export const TELEMETRY_SEVERITY_ORDER: Record<TelemetrySeverity, number> = {
+  critical: 3,
+  warning: 2,
+  info: 1
+};
+
+export const getSeverityLabel = (severity: TelemetrySeverity) => {
+  switch (severity) {
+    case 'critical':
+      return 'Critical';
+    case 'warning':
+      return 'Warning';
+    default:
+      return 'Info';
+  }
+};
+
+export const getIncidentStatusLabel = (status: TelemetryIncident['status']) => {
+  switch (status) {
+    case 'acknowledged':
+      return 'Acknowledged';
+    case 'resolved':
+      return 'Resolved';
+    default:
+      return 'Open';
+  }
+};
+
+export const sortIncidents = <T extends { severity: TelemetrySeverity; createdAt: string }>(
+  incidents: T[]
+) => {
+  return [...incidents].sort((a, b) => {
+    const severityDelta =
+      TELEMETRY_SEVERITY_ORDER[b.severity] - TELEMETRY_SEVERITY_ORDER[a.severity];
+    if (severityDelta !== 0) {
+      return severityDelta;
+    }
+
+    return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+  });
+};
+
+export const isIncidentActive = (incident: TelemetryIncident) =>
+  incident.status === 'open' || incident.status === 'acknowledged';

--- a/src/utils/telemetryClient.ts
+++ b/src/utils/telemetryClient.ts
@@ -1,0 +1,39 @@
+import {
+  HealthPayload,
+  IncidentPayload,
+  TelemetryHealthAlert,
+  TelemetryIncident
+} from '../types';
+import { useTelemetryStore } from '../stores/telemetryStore';
+
+class TelemetryClient {
+  reportIncident(payload: IncidentPayload): TelemetryIncident {
+    return useTelemetryStore.getState().reportIncident(payload);
+  }
+
+  reportHealth(payload: HealthPayload): TelemetryHealthAlert {
+    return useTelemetryStore.getState().reportHealth(payload);
+  }
+
+  acknowledgeIncident(incidentId: string) {
+    useTelemetryStore.getState().acknowledgeIncident(incidentId);
+  }
+
+  resolveIncident(incidentId: string, note?: string): TelemetryIncident | null {
+    return useTelemetryStore.getState().resolveIncident(incidentId, note);
+  }
+
+  clearResolved() {
+    useTelemetryStore.getState().clearResolved();
+  }
+
+  getActiveIncident(): TelemetryIncident | null {
+    return useTelemetryStore.getState().getActiveIncident();
+  }
+
+  getOpenIncidents(limit?: number): TelemetryIncident[] {
+    return useTelemetryStore.getState().getOpenIncidents(limit);
+  }
+}
+
+export const telemetryClient = new TelemetryClient();


### PR DESCRIPTION
## Summary
- add telemetry types, a persisted store, and a lightweight client for reporting incidents and health alerts
- extend the status indicator so telemetry issues surface with accessible severity styling and tooltip details
- introduce a reusable TelemetryLog component and mount it in BackOffice alongside documentation updates

## Testing
- npm run lint *(fails: existing lint errors in POS.tsx, Portal.tsx, PaperShader.tsx, themeStore.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68cffb417c7c832696f94a523d5a81ff