### PR TITLE
feat: add launcher service and portal metadata

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -118,10 +118,21 @@
 ---
 
 ## Agent 10 — Database/Functionality Checks
-**Scope:** Ensure functional logic and DB integration still work after UI changes.  
-**Tasks:**  
-- Verify forms still submit correctly.  
-- Confirm API/data fetching unaffected.  
-- Log any issues needing backend fixes.  
-**Status:** TODO  
-**Log:**  
+**Scope:** Ensure functional logic and DB integration still work after UI changes.
+**Tasks:**
+- Verify forms still submit correctly.
+- Confirm API/data fetching unaffected.
+- Log any issues needing backend fixes.
+**Status:** TODO
+**Log:**
+
+---
+
+## Agent 23 — Launcher Experience
+**Scope:** Application launcher metadata, filtering, and presentation.
+**Tasks:**
+- Document service-level changes for the launcher.
+- Capture portal UI adjustments tied to the new filtering logic.
+**Status:** DONE
+**Log:**
+- Established a launcher service to handle tier/permission/flag filtering, added metadata to app configs, and refreshed the portal UI to surface badges, counts, and restricted states. Noted existing lint issues in unrelated files when running `npm run lint`.

--- a/src/components/apps/Portal.tsx
+++ b/src/components/apps/Portal.tsx
@@ -1,33 +1,74 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useMemo, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import { gsap } from 'gsap';
 import * as LucideIcons from 'lucide-react';
 import { MotionWrapper } from '../ui/MotionWrapper';
 import { useAuthStore } from '../../stores/authStore';
-import { getAvailableApps } from '../../config/apps';
 import { theme } from '../../config/theme';
 import { Card } from '@mas/ui';
+import {
+  buildLauncherState,
+  emptyLauncherState,
+  LauncherApp,
+  LauncherBadgeTone
+} from '../../services/launcherService';
+import { cn } from '../../utils/cn';
 
 const MotionCard = motion(Card);
 
 export const Portal: React.FC = () => {
   const navigate = useNavigate();
   const { user, tenant } = useAuthStore();
-  const gridRef = useRef<HTMLDivElement>(null);
+  const favoritesRef = useRef<HTMLDivElement>(null);
+  const allAppsRef = useRef<HTMLDivElement>(null);
+  const restrictedRef = useRef<HTMLDivElement>(null);
 
-  const availableApps = user ? getAvailableApps(user.role) : [];
+  const launcherState = useMemo(() => {
+    if (!user) {
+      return emptyLauncherState;
+    }
+
+    const tier = user.subscriptionTier ?? tenant?.subscriptionTier ?? 'core';
+    const combinedFeatureFlags = new Set([
+      ...(tenant?.featureFlags ?? []),
+      ...(user.featureFlags ?? [])
+    ]);
+
+    return buildLauncherState({
+      role: user.role,
+      tier,
+      permissions: user.permissions,
+      favorites: user.favoriteApps,
+      featureFlags: Array.from(combinedFeatureFlags)
+    });
+  }, [tenant, user]);
+
+  const accessibleApps = launcherState.accessible;
+  const favoriteApps = launcherState.favorites;
+  const nonFavoriteAccessible = favoriteApps.length
+    ? accessibleApps.filter(app => !app.isFavorite)
+    : accessibleApps;
+  const restrictedApps = launcherState.restricted;
+  const summary = launcherState.summary;
 
   useEffect(() => {
-    if (gridRef.current) {
-      const cards = gridRef.current.children;
+    const animateGrid = (grid: HTMLDivElement | null) => {
+      if (!grid) {
+        return;
+      }
+
+      const cards = Array.from(grid.children);
+      if (!cards.length) {
+        return;
+      }
 
       gsap.fromTo(
         cards,
         {
           y: 24,
           opacity: 0,
-          scale: 0.95,
+          scale: 0.95
         },
         {
           y: 0,
@@ -35,11 +76,104 @@ export const Portal: React.FC = () => {
           scale: 1,
           duration: theme.motion.itemStagger.duration,
           stagger: theme.motion.itemStagger.delay,
-          ease: 'power2.out',
+          ease: 'power2.out'
         }
       );
-    }
-  }, [availableApps]);
+    };
+
+    animateGrid(favoritesRef.current);
+    animateGrid(allAppsRef.current);
+    animateGrid(restrictedRef.current);
+  }, [accessibleApps.length, favoriteApps.length, restrictedApps.length]);
+
+  const badgeToneClasses: Record<LauncherBadgeTone, string> = {
+    neutral: 'bg-surface-200 text-muted',
+    info: 'bg-primary-100 text-primary-600',
+    success: 'bg-success/10 text-success',
+    warning: 'bg-warning/10 text-warning',
+    danger: 'bg-danger/10 text-danger'
+  };
+
+  const renderAppCard = (app: LauncherApp) => {
+    const IconComponent =
+      (LucideIcons as Record<string, React.ComponentType<{ size?: number; className?: string }>>)[
+        app.icon
+      ] || LucideIcons.Package;
+
+    return (
+      <MotionCard
+        key={app.id}
+        whileHover={app.isAccessible ? { scale: 1.02, boxShadow: theme.elevation.modal } : undefined}
+        whileTap={app.isAccessible ? { scale: 0.98 } : undefined}
+        padding
+        className={cn(
+          'border-line/70 transition-all duration-200 group shadow-sm hover:shadow-md',
+          app.isAccessible
+            ? 'cursor-pointer hover:border-primary-200'
+            : 'cursor-not-allowed opacity-75'
+        )}
+        onClick={() => {
+          if (app.isAccessible) {
+            handleAppClick(app.route);
+          }
+        }}
+        aria-disabled={!app.isAccessible}
+      >
+        <div className="flex items-start justify-between mb-4">
+          <div
+            className={cn(
+              'p-3 rounded-lg bg-primary-100 transition-colors',
+              app.isAccessible ? 'group-hover:bg-primary-500' : 'opacity-70'
+            )}
+          >
+            <IconComponent
+              size={24}
+              className={cn(
+                'transition-colors',
+                app.isAccessible ? 'text-primary-600 group-hover:text-white' : 'text-muted'
+              )}
+            />
+          </div>
+
+          <div className="flex items-center gap-2">
+            {app.badge && (
+              <span
+                className={cn(
+                  'text-xs font-medium px-2 py-1 rounded',
+                  badgeToneClasses[app.badge.tone]
+                )}
+              >
+                {app.badge.label}
+              </span>
+            )}
+
+            {app.hasNotifications && <div className="w-2 h-2 rounded-full bg-danger animate-pulse" />}
+
+            {app.isPWA && (
+              <div className="text-xs text-muted font-medium px-2 py-1 bg-surface-200 rounded">
+                PWA
+              </div>
+            )}
+          </div>
+        </div>
+
+        <h3
+          className={cn(
+            'font-semibold text-lg mb-2 transition-colors',
+            app.isAccessible ? 'group-hover:text-primary-600' : 'text-ink-70'
+          )}
+        >
+          {app.name}
+        </h3>
+
+        <p className="text-muted text-sm leading-relaxed">{app.description}</p>
+
+        {!app.isAccessible && app.restrictionReasons.length > 0 && (
+          <p className="text-xs text-muted mt-3">{app.restrictionReasons[0]}</p>
+        )}
+      </MotionCard>
+    );
+  };
 
   const handleAppClick = (route: string) => {
     navigate(route);
@@ -48,47 +182,77 @@ export const Portal: React.FC = () => {
   return (
     <MotionWrapper type="page" className="p-6">
       <div className="max-w-7xl mx-auto">
-        <div className="mb-8">
-          <h2 className="text-3xl font-bold mb-2">Welcome back, {user?.name}</h2>
-          <p className="text-muted">
-            {tenant?.name} • {user?.role}
-          </p>
+        <div className="mb-8 flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
+          <div>
+            <h2 className="text-3xl font-bold mb-2">Welcome back, {user?.name}</h2>
+            <p className="text-muted">
+              {tenant?.name} • {user?.role}
+            </p>
+          </div>
+
+          <div className="flex items-center gap-2 text-sm text-muted">
+            <span>{summary.accessible} apps</span>
+            <span aria-hidden="true">•</span>
+            <span>{summary.favorites} favorites</span>
+            {summary.restricted > 0 && (
+              <>
+                <span aria-hidden="true">•</span>
+                <span>{summary.restricted} restricted</span>
+              </>
+            )}
+          </div>
         </div>
 
-        <div ref={gridRef} className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
-          {availableApps.map((app) => {
-            const IconComponent = (LucideIcons as any)[app.icon] || LucideIcons.Package;
+        {favoriteApps.length > 0 && (
+          <section className="mb-10">
+            <div className="flex items-center justify-between mb-4">
+              <h3 className="text-lg font-semibold">Favorites</h3>
+              <span className="text-sm text-muted">{favoriteApps.length}</span>
+            </div>
+            <div
+              ref={favoritesRef}
+              className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6"
+            >
+              {favoriteApps.map(renderAppCard)}
+            </div>
+          </section>
+        )}
 
-            return (
-              <MotionCard
-                key={app.id}
-                whileHover={{ scale: 1.02, boxShadow: theme.elevation.modal }}
-                whileTap={{ scale: 0.98 }}
-                padding
-                className="cursor-pointer border-line/70 hover:border-primary-200 transition-all duration-200 group shadow-sm hover:shadow-md"
-                onClick={() => handleAppClick(app.route)}
-              >
-                <div className="flex items-start justify-between mb-4">
-                  <div className="p-3 rounded-lg bg-primary-100 group-hover:bg-primary-500 transition-colors">
-                    <IconComponent size={24} className="text-primary-600 group-hover:text-white transition-colors" />
-                  </div>
+        <section className="mb-10">
+          <div className="flex items-center justify-between mb-4">
+            <h3 className="text-lg font-semibold">All applications</h3>
+            <span className="text-sm text-muted">{nonFavoriteAccessible.length}</span>
+          </div>
+          {nonFavoriteAccessible.length > 0 ? (
+            <div
+              ref={allAppsRef}
+              className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6"
+            >
+              {nonFavoriteAccessible.map(renderAppCard)}
+            </div>
+          ) : (
+            <div className="rounded-lg border border-dashed border-line/70 p-6 text-center text-sm text-muted">
+              {favoriteApps.length
+                ? 'All available apps are pinned as favorites.'
+                : 'No applications available for your profile yet.'}
+            </div>
+          )}
+        </section>
 
-                  {app.hasNotifications && <div className="w-2 h-2 rounded-full bg-danger animate-pulse" />}
-
-                  {app.isPWA && (
-                    <div className="text-xs text-muted font-medium px-2 py-1 bg-surface-200 rounded">
-                      PWA
-                    </div>
-                  )}
-                </div>
-
-                <h3 className="font-semibold text-lg mb-2 group-hover:text-primary-600 transition-colors">{app.name}</h3>
-
-                <p className="text-muted text-sm leading-relaxed">{app.description}</p>
-              </MotionCard>
-            );
-          })}
-        </div>
+        {restrictedApps.length > 0 && (
+          <section className="mb-12">
+            <div className="flex items-center justify-between mb-4">
+              <h3 className="text-lg font-semibold">Restricted</h3>
+              <span className="text-sm text-muted">{restrictedApps.length}</span>
+            </div>
+            <div
+              ref={restrictedRef}
+              className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6"
+            >
+              {restrictedApps.map(renderAppCard)}
+            </div>
+          </section>
+        )}
 
         <div className="mt-12 grid grid-cols-1 lg:grid-cols-3 gap-6">
           <Card>

--- a/src/config/apps.ts
+++ b/src/config/apps.ts
@@ -7,7 +7,8 @@ export const appConfigs: AppConfig[] = [
     description: 'Access all applications',
     icon: 'Grid3x3',
     route: '/portal',
-    roles: ['cashier', 'waiter', 'bartender', 'supervisor', 'manager', 'owner']
+    roles: ['cashier', 'waiter', 'bartender', 'supervisor', 'manager', 'owner'],
+    tier: 'core'
   },
   {
     id: 'pos',
@@ -16,6 +17,9 @@ export const appConfigs: AppConfig[] = [
     icon: 'ShoppingCart',
     route: '/pos',
     roles: ['cashier', 'waiter', 'bartender', 'supervisor', 'manager', 'owner'],
+    tier: 'core',
+    permissions: ['orders:manage'],
+    featureFlags: ['pwa-ready'],
     isPWA: true
   },
   {
@@ -24,7 +28,10 @@ export const appConfigs: AppConfig[] = [
     description: 'Manage kitchen orders',
     icon: 'Chef',
     route: '/kds',
-    roles: ['supervisor', 'manager', 'owner']
+    roles: ['supervisor', 'manager', 'owner'],
+    tier: 'plus',
+    permissions: ['kitchen:manage'],
+    featureFlags: ['kitchen-suite']
   },
   {
     id: 'products',
@@ -32,7 +39,9 @@ export const appConfigs: AppConfig[] = [
     description: 'Manage products and categories',
     icon: 'Package',
     route: '/products',
-    roles: ['manager', 'owner']
+    roles: ['manager', 'owner'],
+    tier: 'plus',
+    permissions: ['catalog:manage']
   },
   {
     id: 'inventory',
@@ -40,7 +49,9 @@ export const appConfigs: AppConfig[] = [
     description: 'Stock management and tracking',
     icon: 'Archive',
     route: '/inventory',
-    roles: ['manager', 'owner']
+    roles: ['manager', 'owner'],
+    tier: 'plus',
+    permissions: ['inventory:manage']
   },
   {
     id: 'customers',
@@ -48,7 +59,9 @@ export const appConfigs: AppConfig[] = [
     description: 'Customer management and loyalty',
     icon: 'Users',
     route: '/customers',
-    roles: ['cashier', 'waiter', 'bartender', 'supervisor', 'manager', 'owner']
+    roles: ['cashier', 'waiter', 'bartender', 'supervisor', 'manager', 'owner'],
+    tier: 'core',
+    permissions: ['customers:manage']
   },
   {
     id: 'promotions',
@@ -56,7 +69,9 @@ export const appConfigs: AppConfig[] = [
     description: 'Discounts and promotional rules',
     icon: 'Percent',
     route: '/promotions',
-    roles: ['supervisor', 'manager', 'owner']
+    roles: ['supervisor', 'manager', 'owner'],
+    tier: 'plus',
+    permissions: ['promotions:manage']
   },
   {
     id: 'reports',
@@ -64,7 +79,10 @@ export const appConfigs: AppConfig[] = [
     description: 'Sales and analytics reports',
     icon: 'BarChart3',
     route: '/reports',
-    roles: ['supervisor', 'manager', 'owner']
+    roles: ['supervisor', 'manager', 'owner'],
+    tier: 'premium',
+    permissions: ['reports:view'],
+    featureFlags: ['preview:analytics-v2']
   },
   {
     id: 'calendar',
@@ -72,7 +90,10 @@ export const appConfigs: AppConfig[] = [
     description: 'Reservations and scheduling',
     icon: 'Calendar',
     route: '/calendar',
-    roles: ['waiter', 'supervisor', 'manager', 'owner']
+    roles: ['waiter', 'supervisor', 'manager', 'owner'],
+    tier: 'plus',
+    permissions: ['calendar:manage'],
+    featureFlags: ['beta:calendar']
   },
   {
     id: 'accounting',
@@ -80,7 +101,9 @@ export const appConfigs: AppConfig[] = [
     description: 'Financial reporting and management',
     icon: 'DollarSign',
     route: '/accounting',
-    roles: ['manager', 'owner']
+    roles: ['manager', 'owner'],
+    tier: 'premium',
+    permissions: ['accounting:view']
   },
   {
     id: 'backoffice',
@@ -88,7 +111,10 @@ export const appConfigs: AppConfig[] = [
     description: 'Settings and administration',
     icon: 'Settings',
     route: '/backoffice',
-    roles: ['manager', 'owner']
+    roles: ['manager', 'owner'],
+    tier: 'premium',
+    permissions: ['settings:manage'],
+    featureFlags: ['preview:operations']
   }
 ];
 

--- a/src/data/mockData.ts
+++ b/src/data/mockData.ts
@@ -13,7 +13,9 @@ export const mockTenant: Tenant = {
       animationSpeed: 1.0,
       surfaces: ['background', 'cards']
     }
-  }
+  },
+  subscriptionTier: 'plus',
+  featureFlags: ['beta:calendar']
 };
 
 export const mockStore: Store = {
@@ -30,7 +32,21 @@ export const mockUser: User = {
   name: 'Sarah Johnson',
   role: 'manager',
   storeId: 'store-1',
-  pin: '1234'
+  pin: '1234',
+  subscriptionTier: 'plus',
+  permissions: [
+    'orders:manage',
+    'kitchen:manage',
+    'catalog:manage',
+    'inventory:manage',
+    'customers:manage',
+    'promotions:manage',
+    'calendar:manage',
+    'reports:view',
+    'settings:manage'
+  ],
+  favoriteApps: ['pos', 'calendar', 'reports'],
+  featureFlags: ['preview:analytics-v2']
 };
 
 export const mockCategories: Category[] = [

--- a/src/services/launcherService.ts
+++ b/src/services/launcherService.ts
@@ -1,0 +1,167 @@
+import { appConfigs } from '../config/apps';
+import { AppConfig, AppPermission, AppTier, UserRole } from '../types';
+
+const tierRank: Record<AppTier, number> = {
+  core: 0,
+  plus: 1,
+  premium: 2
+};
+
+const permissionLabels: Record<AppPermission, string> = {
+  'orders:manage': 'Orders',
+  'kitchen:manage': 'Kitchen',
+  'catalog:manage': 'Product catalog',
+  'inventory:manage': 'Inventory',
+  'customers:manage': 'Customers',
+  'promotions:manage': 'Promotions',
+  'reports:view': 'Reports',
+  'calendar:manage': 'Calendar',
+  'accounting:view': 'Accounting',
+  'settings:manage': 'Settings'
+};
+
+const capitalizeWords = (value: string) =>
+  value
+    .split(' ')
+    .map(word => (word.length ? word[0].toUpperCase() + word.slice(1) : word))
+    .join(' ');
+
+const formatPermissionList = (permissions: AppPermission[]): string =>
+  permissions
+    .map(permission => permissionLabels[permission] ?? permission)
+    .map(label => capitalizeWords(label))
+    .join(', ');
+
+const formatFlagName = (flag: string): string => {
+  const normalized = flag.includes(':') ? flag.split(':')[1] : flag;
+  return capitalizeWords(normalized.replace(/[-_]/g, ' '));
+};
+
+const isNewFlag = (flag: string): boolean =>
+  flag.startsWith('beta:') || flag.startsWith('preview:');
+
+export type LauncherBadgeTone = 'neutral' | 'info' | 'success' | 'warning' | 'danger';
+
+export interface LauncherBadge {
+  label: string;
+  tone: LauncherBadgeTone;
+}
+
+export interface LauncherApp extends AppConfig {
+  isAccessible: boolean;
+  isFavorite: boolean;
+  badge?: LauncherBadge;
+  restrictionReasons: string[];
+}
+
+export interface LauncherSummary {
+  total: number;
+  accessible: number;
+  favorites: number;
+  restricted: number;
+}
+
+export interface LauncherState {
+  all: LauncherApp[];
+  accessible: LauncherApp[];
+  restricted: LauncherApp[];
+  favorites: LauncherApp[];
+  summary: LauncherSummary;
+}
+
+export interface LauncherContext {
+  role: UserRole;
+  tier: AppTier;
+  permissions?: AppPermission[];
+  favorites?: string[];
+  featureFlags?: string[];
+}
+
+export const emptyLauncherState: LauncherState = {
+  all: [],
+  accessible: [],
+  restricted: [],
+  favorites: [],
+  summary: {
+    total: 0,
+    accessible: 0,
+    favorites: 0,
+    restricted: 0
+  }
+};
+
+export const buildLauncherState = (context: LauncherContext): LauncherState => {
+  const favoritesSet = new Set(context.favorites ?? []);
+  const permissionsSet = new Set(context.permissions ?? []);
+  const featureFlagSet = new Set(context.featureFlags ?? []);
+
+  const all: LauncherApp[] = appConfigs.map((appConfig: AppConfig) => {
+    const restrictionReasons: string[] = [];
+
+    if (!appConfig.roles.includes(context.role)) {
+      restrictionReasons.push('Unavailable for your role');
+    }
+
+    if (tierRank[context.tier] < tierRank[appConfig.tier]) {
+      restrictionReasons.push(`Requires ${capitalizeWords(appConfig.tier)} plan`);
+    }
+
+    if (appConfig.permissions?.length) {
+      const missingPermissions = appConfig.permissions.filter(
+        permission => !permissionsSet.has(permission)
+      );
+
+      if (missingPermissions.length) {
+        restrictionReasons.push(
+          `Missing permissions: ${formatPermissionList(missingPermissions)}`
+        );
+      }
+    }
+
+    if (appConfig.featureFlags?.length) {
+      const missingFlags = appConfig.featureFlags.filter(flag => !featureFlagSet.has(flag));
+
+      if (missingFlags.length) {
+        restrictionReasons.push(
+          `Feature flag required: ${missingFlags.map(formatFlagName).join(', ')}`
+        );
+      }
+    }
+
+    const isAccessible = restrictionReasons.length === 0;
+    const isFavorite = favoritesSet.has(appConfig.id);
+
+    let badge: LauncherBadge | undefined;
+
+    if (!isAccessible) {
+      badge = { label: 'Restricted', tone: 'warning' };
+    } else if (appConfig.featureFlags?.some(isNewFlag)) {
+      badge = { label: 'New', tone: 'info' };
+    }
+
+    return {
+      ...appConfig,
+      isAccessible,
+      isFavorite,
+      badge,
+      restrictionReasons
+    };
+  });
+
+  const accessible = all.filter(app => app.isAccessible);
+  const restricted = all.filter(app => !app.isAccessible);
+  const favorites = accessible.filter(app => app.isFavorite);
+
+  return {
+    all,
+    accessible,
+    restricted,
+    favorites,
+    summary: {
+      total: all.length,
+      accessible: accessible.length,
+      favorites: favorites.length,
+      restricted: restricted.length
+    }
+  };
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -3,6 +3,8 @@ export interface Tenant {
   id: string;
   name: string;
   settings: TenantSettings;
+  subscriptionTier?: AppTier;
+  featureFlags?: string[];
 }
 
 export interface TenantSettings {
@@ -33,6 +35,10 @@ export interface User {
   storeId: string;
   pin?: string;
   lastLogin?: Date;
+  subscriptionTier?: AppTier;
+  permissions?: AppPermission[];
+  favoriteApps?: string[];
+  featureFlags?: string[];
 }
 
 export type UserRole = 'cashier' | 'waiter' | 'bartender' | 'supervisor' | 'manager' | 'owner';
@@ -162,6 +168,20 @@ export interface KdsItem {
 }
 
 // App routing
+export type AppTier = 'core' | 'plus' | 'premium';
+
+export type AppPermission =
+  | 'orders:manage'
+  | 'kitchen:manage'
+  | 'catalog:manage'
+  | 'inventory:manage'
+  | 'customers:manage'
+  | 'promotions:manage'
+  | 'reports:view'
+  | 'calendar:manage'
+  | 'accounting:view'
+  | 'settings:manage';
+
 export interface AppConfig {
   id: string;
   name: string;
@@ -169,6 +189,9 @@ export interface AppConfig {
   icon: string;
   route: string;
   roles: UserRole[];
+  tier: AppTier;
+  permissions?: AppPermission[];
+  featureFlags?: string[];
   isFavorite?: boolean;
   hasNotifications?: boolean;
   isPWA?: boolean;


### PR DESCRIPTION
## Summary
- add a launcher service that encapsulates role, tier, permission, and feature-flag filtering while emitting badge metadata
- extend the app configuration and mock auth data with tier, permission, and feature-flag details used by the launcher logic
- refresh the Portal experience to show favorites, restricted states, and badge/count surfaces, and document the behavior under Agent 23

## Testing
- npm run lint *(fails: existing unused imports and escape character warnings in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cffb40e5e48326a7a8a48e400849b4