### PR TITLE
Add BackOffice device diagnostics card

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -118,10 +118,34 @@
 ---
 
 ## Agent 10 — Database/Functionality Checks
-**Scope:** Ensure functional logic and DB integration still work after UI changes.  
-**Tasks:**  
-- Verify forms still submit correctly.  
-- Confirm API/data fetching unaffected.  
-- Log any issues needing backend fixes.  
-**Status:** TODO  
-**Log:**  
+**Scope:** Ensure functional logic and DB integration still work after UI changes.
+**Tasks:**
+- Verify forms still submit correctly.
+- Confirm API/data fetching unaffected.
+- Log any issues needing backend fixes.
+**Status:** TODO
+**Log:**
+
+---
+
+## Agent 11 — BackOffice Devices
+**Scope:** Backoffice hardware visibility and quick diagnostics UI.
+**Tasks:**
+- Surface registered device metadata.
+- Provide connection controls with optimistic updates.
+- Wire hardware test actions with async placeholders.
+**Status:** DONE
+**Log:**
+- Added a hardware devices card with mocked metadata, optimistic connect/disconnect toggles, and offline-aware action handlers that log outcomes.
+
+---
+
+## Agent 20 — QA & Testing
+**Scope:** Track verification steps and outcomes across the suite.
+**Tasks:**
+- Run relevant automated checks.
+- Document pass/fail results with context.
+- Flag blocking issues for follow-up.
+**Status:** DONE
+**Log:**
+- Ran `npm run lint`; command fails because of pre-existing lint violations in POS, Portal, PaperShader, StatusIndicator, and themeStore modules. BackOffice additions introduce no new errors.

--- a/src/components/apps/BackOffice.tsx
+++ b/src/components/apps/BackOffice.tsx
@@ -1,6 +1,18 @@
 import React from 'react';
 import { Card, Button } from '@mas/ui';
 import { useTheme } from '../../stores/themeStore';
+import { mockDevices, type MockDevice } from '../../data/mockDevices';
+
+const simulateDelay = (base = 450, variance = 300) =>
+  new Promise<void>((resolve) => setTimeout(resolve, base + Math.random() * variance));
+
+const formatLastSeen = (timestamp: string) =>
+  new Intl.DateTimeFormat(undefined, {
+    month: 'short',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit'
+  }).format(new Date(timestamp));
 
 const themeModes = [
   { id: 'light', label: 'Light' },
@@ -12,6 +24,11 @@ const paperSurfaces: Array<'background' | 'cards'> = ['background', 'cards'];
 
 export const BackOffice: React.FC = () => {
   const { mode, paperShader, setMode, updatePaperShader } = useTheme();
+  const [devices, setDevices] = React.useState<MockDevice[]>(() =>
+    mockDevices.map((device) => ({ ...device }))
+  );
+  const [connectionPending, setConnectionPending] = React.useState<Record<string, boolean>>({});
+  const [activeTests, setActiveTests] = React.useState<Record<string, 'print' | 'drawer' | undefined>>({});
 
   const toggleSurface = (surface: 'background' | 'cards') => {
     const set = new Set(paperShader.surfaces);
@@ -22,6 +39,82 @@ export const BackOffice: React.FC = () => {
     }
     const next = Array.from(set);
     updatePaperShader({ surfaces: next.length ? next : ['background'] });
+  };
+
+  const connectDevice = async (device: MockDevice) => {
+    console.log(`[devices] connecting to ${device.name} (${device.id})`);
+    await simulateDelay();
+    console.log(`[devices] ${device.name} connected`);
+  };
+
+  const disconnectDevice = async (device: MockDevice) => {
+    console.log(`[devices] disconnecting ${device.name} (${device.id})`);
+    await simulateDelay();
+    console.log(`[devices] ${device.name} disconnected`);
+  };
+
+  const runDeviceTest = async (device: MockDevice, action: 'print' | 'drawer') => {
+    if (!device.connected) {
+      console.warn(`[devices] skipped ${action} test for ${device.name} - device offline`);
+      return;
+    }
+
+    const label = action === 'print' ? 'print receipt' : 'drawer cycle';
+    console.log(`[devices] starting ${label} for ${device.name}`);
+    await simulateDelay(520, 360);
+    console.log(`[devices] completed ${label} for ${device.name}`);
+  };
+
+  const handleToggleConnection = async (deviceId: string) => {
+    const device = devices.find((item) => item.id === deviceId);
+    if (!device) {
+      return;
+    }
+
+    const nextConnected = !device.connected;
+    setDevices((prev) =>
+      prev.map((item) => (item.id === deviceId ? { ...item, connected: nextConnected } : item))
+    );
+    setConnectionPending((prev) => ({ ...prev, [deviceId]: true }));
+
+    try {
+      if (nextConnected) {
+        await connectDevice({ ...device, connected: nextConnected });
+      } else {
+        await disconnectDevice({ ...device, connected: nextConnected });
+      }
+
+      const timestamp = new Date().toISOString();
+      setDevices((prev) =>
+        prev.map((item) => (item.id === deviceId ? { ...item, lastSeen: timestamp } : item))
+      );
+    } catch (error) {
+      console.error('[devices] failed to update connection state', error);
+      setDevices((prev) =>
+        prev.map((item) => (item.id === deviceId ? { ...item, connected: device.connected } : item))
+      );
+    } finally {
+      setConnectionPending((prev) => {
+        const next = { ...prev };
+        delete next[deviceId];
+        return next;
+      });
+    }
+  };
+
+  const handleRunTest = async (deviceId: string, action: 'print' | 'drawer') => {
+    const device = devices.find((item) => item.id === deviceId);
+    if (!device || !device.connected) {
+      console.warn(`[devices] cannot run ${action} on ${device?.name ?? deviceId} - offline`);
+      return;
+    }
+
+    setActiveTests((prev) => ({ ...prev, [deviceId]: action }));
+    try {
+      await runDeviceTest(device, action);
+    } finally {
+      setActiveTests((prev) => ({ ...prev, [deviceId]: undefined }));
+    }
   };
 
   return (
@@ -151,6 +244,109 @@ export const BackOffice: React.FC = () => {
                 </p>
               </Card>
             ))}
+          </div>
+        </Card>
+
+        <Card className="space-y-6">
+          <div>
+            <h2 className="text-xl font-semibold">Hardware Devices</h2>
+            <p className="text-muted text-sm">
+              Monitor printer and drawer connectivity. Use the quick actions to validate receipts or
+              cycle peripherals before service.
+            </p>
+          </div>
+
+          <div className="space-y-4">
+            {devices.map((device) => {
+              const connectionLoading = Boolean(connectionPending[device.id]);
+              const currentTest = activeTests[device.id];
+              const offline = !device.connected;
+
+              return (
+                <div
+                  key={device.id}
+                  className="rounded-xl border border-line bg-surface-100/70 p-4 space-y-3"
+                >
+                  <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
+                    <div className="space-y-1">
+                      <div className="flex items-center gap-2">
+                        <p className="text-base font-semibold text-ink">{device.name}</p>
+                        <span
+                          className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${
+                            device.connected
+                              ? 'bg-success/10 text-success'
+                              : 'bg-warning/10 text-warning'
+                          }`}
+                        >
+                          {device.connected ? 'Online' : 'Offline'}
+                        </span>
+                      </div>
+                      <p className="text-sm text-muted">
+                        {device.type} • {device.location}
+                      </p>
+                      <p className="text-xs text-muted">
+                        {device.model} · {device.ipAddress} · Last seen {formatLastSeen(device.lastSeen)}
+                      </p>
+                    </div>
+
+                    <Button
+                      variant={device.connected ? 'secondary' : 'primary'}
+                      size="sm"
+                      onClick={() => handleToggleConnection(device.id)}
+                      disabled={connectionLoading}
+                      aria-pressed={device.connected}
+                      aria-busy={connectionLoading}
+                    >
+                      {connectionLoading
+                        ? device.connected
+                          ? 'Disconnecting…'
+                          : 'Connecting…'
+                        : device.connected
+                        ? 'Disconnect'
+                        : 'Connect'}
+                    </Button>
+                  </div>
+
+                  <div className="flex flex-wrap items-center gap-2">
+                    {device.capabilities.includes('print') && (
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => handleRunTest(device.id, 'print')}
+                        disabled={offline || Boolean(currentTest) || connectionLoading}
+                        aria-disabled={offline || Boolean(currentTest) || connectionLoading}
+                      >
+                        {currentTest === 'print' ? 'Running print test…' : 'Print test receipt'}
+                      </Button>
+                    )}
+
+                    {device.capabilities.includes('drawer') && (
+                      <Button
+                        variant="secondary"
+                        size="sm"
+                        onClick={() => handleRunTest(device.id, 'drawer')}
+                        disabled={offline || Boolean(currentTest) || connectionLoading}
+                        aria-disabled={offline || Boolean(currentTest) || connectionLoading}
+                      >
+                        {currentTest === 'drawer' ? 'Cycling drawer…' : 'Cycle cash drawer'}
+                      </Button>
+                    )}
+
+                    {device.capabilities.length === 0 && (
+                      <span className="text-xs text-muted">
+                        No remote actions available for this device.
+                      </span>
+                    )}
+
+                    {offline && device.capabilities.length > 0 && (
+                      <span className="text-xs font-medium text-warning">
+                        Device offline — reconnect to run tests.
+                      </span>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
           </div>
         </Card>
       </div>

--- a/src/data/mockDevices.ts
+++ b/src/data/mockDevices.ts
@@ -1,0 +1,65 @@
+export type DeviceCapability = 'print' | 'drawer';
+
+export interface MockDevice {
+  id: string;
+  name: string;
+  type: 'Receipt Printer' | 'Kitchen Printer' | 'Cash Drawer' | 'Barcode Scanner';
+  location: string;
+  model: string;
+  ipAddress: string;
+  firmware: string;
+  lastSeen: string;
+  connected: boolean;
+  capabilities: DeviceCapability[];
+}
+
+export const mockDevices: MockDevice[] = [
+  {
+    id: 'device-01',
+    name: 'Front Counter Printer',
+    type: 'Receipt Printer',
+    location: 'Register 1',
+    model: 'Epson TM-T88VI',
+    ipAddress: '10.10.0.21',
+    firmware: 'v3.2.5',
+    lastSeen: '2024-09-18T14:32:00.000Z',
+    connected: true,
+    capabilities: ['print']
+  },
+  {
+    id: 'device-02',
+    name: 'Cash Drawer',
+    type: 'Cash Drawer',
+    location: 'Register 2',
+    model: 'APG Series 4000',
+    ipAddress: '10.10.0.30',
+    firmware: 'v1.4.0',
+    lastSeen: '2024-09-18T13:58:00.000Z',
+    connected: true,
+    capabilities: ['drawer']
+  },
+  {
+    id: 'device-03',
+    name: 'Kitchen Pass Printer',
+    type: 'Kitchen Printer',
+    location: 'Kitchen',
+    model: 'Star mC-Print3',
+    ipAddress: '10.10.0.45',
+    firmware: 'v2.9.1',
+    lastSeen: '2024-09-18T12:15:00.000Z',
+    connected: false,
+    capabilities: ['print']
+  },
+  {
+    id: 'device-04',
+    name: 'Bar Scanner',
+    type: 'Barcode Scanner',
+    location: 'Bar Station',
+    model: 'Zebra DS2208',
+    ipAddress: '10.10.0.55',
+    firmware: 'v5.1.3',
+    lastSeen: '2024-09-18T12:46:00.000Z',
+    connected: true,
+    capabilities: []
+  }
+];


### PR DESCRIPTION
## Summary
- add mocked hardware metadata in `src/data/mockDevices.ts`
- extend the BackOffice screen with a hardware devices card, optimistic connection toggles, and offline-aware test actions
- document the work and lint outcome in the agent task log

## Testing
- npm run lint *(fails: existing lint violations in POS, Portal, PaperShader, StatusIndicator, and themeStore modules)*

------
https://chatgpt.com/codex/tasks/task_e_68cffb42631c8326a5649dc14b9dd669