### PR TITLE
Agent25: add MFA UI and PIN authorization flows

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -118,10 +118,22 @@
 ---
 
 ## Agent 10 — Database/Functionality Checks
-**Scope:** Ensure functional logic and DB integration still work after UI changes.  
-**Tasks:**  
-- Verify forms still submit correctly.  
-- Confirm API/data fetching unaffected.  
-- Log any issues needing backend fixes.  
-**Status:** TODO  
-**Log:**  
+**Scope:** Ensure functional logic and DB integration still work after UI changes.
+**Tasks:**
+- Verify forms still submit correctly.
+- Confirm API/data fetching unaffected.
+- Log any issues needing backend fixes.
+**Status:** TODO
+**Log:**
+
+---
+
+## Agent 25 — Security & Access Controls
+**Scope:** POS overrides, authentication safeguards, MFA UX.
+**Tasks:**
+- Add hashed PIN validation for restricted POS actions.
+- Surface multi-factor setup & recovery management in BackOffice.
+- Ensure auth store tracks role permissions & MFA lifecycle.
+**Status:** DONE
+**Log:**
+- 2024-11-24: Implemented hashed PIN verification with modal override flows in POS, expanded auth store to manage MFA + role policies, and shipped BackOffice MFA setup UI with recovery rotation. No follow-ups pending; real backend wiring required when available.

--- a/src/components/apps/BackOffice.tsx
+++ b/src/components/apps/BackOffice.tsx
@@ -1,6 +1,9 @@
-import React from 'react';
+import React, { useMemo, useState } from 'react';
 import { Card, Button } from '@mas/ui';
+import { ShieldCheck, RefreshCw, KeyRound, AlertCircle } from 'lucide-react';
 import { useTheme } from '../../stores/themeStore';
+import { useAuthStore } from '../../stores/authStore';
+import { RestrictedPosAction } from '../../types';
 
 const themeModes = [
   { id: 'light', label: 'Light' },
@@ -12,6 +15,28 @@ const paperSurfaces: Array<'background' | 'cards'> = ['background', 'cards'];
 
 export const BackOffice: React.FC = () => {
   const { mode, paperShader, setMode, updatePaperShader } = useTheme();
+  const {
+    mfa,
+    beginMfaEnrollment,
+    cancelMfaEnrollment,
+    verifyMfaCode,
+    rotateRecoveryCodes,
+    clearMfa,
+    rolePermissions,
+    user
+  } = useAuthStore();
+  const [verificationCode, setVerificationCode] = useState('');
+  const [verificationStatus, setVerificationStatus] = useState<'idle' | 'success' | 'error'>('idle');
+  const [codesRotatedAt, setCodesRotatedAt] = useState<string | null>(null);
+
+  const actionLabels: Record<RestrictedPosAction, string> = useMemo(
+    () => ({
+      'void-order': 'Void current order',
+      'process-refund': 'Process refund',
+      'manager-discount': 'Manager discount'
+    }),
+    []
+  );
 
   const toggleSurface = (surface: 'background' | 'cards') => {
     const set = new Set(paperShader.surfaces);
@@ -22,6 +47,28 @@ export const BackOffice: React.FC = () => {
     }
     const next = Array.from(set);
     updatePaperShader({ surfaces: next.length ? next : ['background'] });
+  };
+
+  const handleVerifyMfa = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const success = verifyMfaCode(verificationCode);
+    setVerificationStatus(success ? 'success' : 'error');
+    if (success) {
+      setVerificationCode('');
+      setCodesRotatedAt(null);
+    }
+  };
+
+  const handleRotateCodes = () => {
+    rotateRecoveryCodes();
+    setCodesRotatedAt(new Date().toISOString());
+  };
+
+  const resetMfa = () => {
+    clearMfa();
+    setVerificationCode('');
+    setVerificationStatus('idle');
+    setCodesRotatedAt(null);
   };
 
   return (
@@ -132,6 +179,182 @@ export const BackOffice: React.FC = () => {
             </div>
           </Card>
         </div>
+
+        <Card className="space-y-6">
+          <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+            <div>
+              <h2 className="text-xl font-semibold">Account Security</h2>
+              <p className="text-muted text-sm">
+                Configure multi-factor authentication and review which POS actions require a manager PIN.
+              </p>
+            </div>
+            <div className="rounded-lg border border-line bg-surface-200/60 px-4 py-2 text-sm">
+              <p className="text-muted">MFA status: <span className="font-medium text-ink capitalize">{mfa.status}</span></p>
+              {mfa.lastVerifiedAt && (
+                <p className="text-[11px] text-muted mt-1">Verified {new Date(mfa.lastVerifiedAt).toLocaleString()}</p>
+              )}
+            </div>
+          </div>
+
+          {mfa.status === 'disabled' && (
+            <div className="flex flex-wrap gap-3">
+              <Button onClick={beginMfaEnrollment} className="inline-flex items-center gap-2">
+                <ShieldCheck size={16} /> Enable 2FA
+              </Button>
+              <div className="rounded-lg border border-line bg-surface-200/50 px-4 py-3 text-sm text-muted">
+                Once enabled, you will receive a temporary secret, verification codes, and recovery codes to print or store in a password manager.
+              </div>
+            </div>
+          )}
+
+          {mfa.status === 'pending' && (
+            <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+              <div className="space-y-4">
+                <div>
+                  <h3 className="text-sm font-semibold text-ink flex items-center gap-2">
+                    <KeyRound size={16} /> Temporary secret
+                  </h3>
+                  <p className="mt-2 rounded-lg border border-dashed border-primary-200 bg-primary-100/40 px-3 py-2 font-mono text-sm tracking-wide text-primary-700">
+                    {mfa.temporarySecret}
+                  </p>
+                  <p className="mt-2 text-xs text-muted">
+                    Enter this secret into your authenticator app and compare the rolling codes below.
+                  </p>
+                </div>
+                <div>
+                  <h3 className="text-sm font-semibold text-ink">Temporary codes</h3>
+                  <div className="mt-2 grid grid-cols-3 gap-2 text-center text-sm font-medium text-ink">
+                    {(mfa.previewCodes ?? []).map((code) => (
+                      <span key={code} className="rounded-lg border border-line bg-surface-100 py-2 font-mono">
+                        {code}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              </div>
+              <div className="space-y-4">
+                <form onSubmit={handleVerifyMfa} className="space-y-3">
+                  <label className="block text-sm font-medium text-ink">
+                    Verification code
+                    <input
+                      value={verificationCode}
+                      onChange={(event) => setVerificationCode(event.target.value)}
+                      inputMode="numeric"
+                      maxLength={6}
+                      className="mt-2 w-full rounded-lg border border-line bg-surface-200/60 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500"
+                      placeholder="Enter 6-digit code"
+                    />
+                  </label>
+                  {verificationStatus === 'error' && (
+                    <p className="flex items-center gap-2 text-sm text-danger">
+                      <AlertCircle size={16} /> Code did not match. Try again within the 30s window.
+                    </p>
+                  )}
+                  {verificationStatus === 'success' && (
+                    <p className="flex items-center gap-2 text-sm text-success">
+                      <ShieldCheck size={16} /> Code accepted. MFA is now active.
+                    </p>
+                  )}
+                  <div className="flex items-center gap-2">
+                    <Button type="submit" className="flex-1">Confirm setup</Button>
+                    <Button type="button" variant="outline" onClick={cancelMfaEnrollment}>
+                      Cancel
+                    </Button>
+                  </div>
+                </form>
+                <div className="rounded-lg border border-line bg-surface-200/60 p-4 text-sm text-muted">
+                  <p className="font-medium text-ink mb-2">Recovery codes</p>
+                  <ul className="grid grid-cols-2 gap-2 font-mono text-xs">
+                    {mfa.recoveryCodes.map((code) => (
+                      <li key={code} className="rounded border border-dashed border-line px-2 py-1 text-center">
+                        {code}
+                      </li>
+                    ))}
+                  </ul>
+                  <p className="mt-2 text-xs text-muted">
+                    Store these safely. Each code can be used once if you lose access to your authenticator.
+                  </p>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {mfa.status === 'verified' && (
+            <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+              <div className="space-y-3">
+                <div className="rounded-lg border border-line bg-surface-100 p-4">
+                  <p className="text-sm font-medium text-ink">Authenticator secret</p>
+                  <p className="mt-2 font-mono text-sm tracking-wide text-muted break-all">
+                    {mfa.temporarySecret}
+                  </p>
+                  <p className="mt-2 text-xs text-muted">
+                    Keep this secret offline. Regenerate from your identity provider if compromised.
+                  </p>
+                </div>
+                <div className="rounded-lg border border-line bg-surface-100 p-4">
+                  <p className="text-sm font-medium text-ink">Rolling codes (preview)</p>
+                  <div className="mt-3 grid grid-cols-3 gap-2 text-center text-sm font-semibold text-ink">
+                    {(mfa.previewCodes ?? []).map((code) => (
+                      <span key={code} className="rounded-lg border border-line bg-surface-200 py-2 font-mono">
+                        {code}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              </div>
+              <div className="space-y-4">
+                <div className="rounded-lg border border-line bg-surface-100 p-4">
+                  <div className="flex items-center justify-between">
+                    <p className="text-sm font-medium text-ink">Recovery codes</p>
+                    <Button variant="outline" size="sm" onClick={handleRotateCodes} className="inline-flex items-center gap-1">
+                      <RefreshCw size={14} /> Rotate
+                    </Button>
+                  </div>
+                  <ul className="mt-3 grid grid-cols-2 gap-2 font-mono text-xs">
+                    {mfa.recoveryCodes.map((code) => (
+                      <li key={code} className="rounded border border-dashed border-line px-2 py-1 text-center">
+                        {code}
+                      </li>
+                    ))}
+                  </ul>
+                  {codesRotatedAt && (
+                    <p className="mt-2 text-[11px] text-muted">New codes generated {new Date(codesRotatedAt).toLocaleString()}.</p>
+                  )}
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  <Button variant="outline" onClick={resetMfa}>Disable 2FA</Button>
+                </div>
+              </div>
+            </div>
+          )}
+
+          <div className="rounded-lg border border-line bg-surface-200/60 p-4">
+            <h3 className="text-sm font-semibold text-ink flex items-center gap-2">
+              <ShieldCheck size={16} /> POS override policy
+            </h3>
+            <p className="mt-2 text-xs text-muted">
+              Role: <span className="font-medium text-ink capitalize">{user?.role ?? 'unknown'}</span>. The following actions require a stored PIN hash for override:
+            </p>
+            <ul className="mt-3 grid grid-cols-1 gap-2 text-sm text-ink md:grid-cols-2">
+              {(rolePermissions?.requiresPin ?? []).length === 0 ? (
+                <li className="rounded border border-line bg-surface-100 px-3 py-2 text-muted">
+                  No PIN overrides are required for this role.
+                </li>
+              ) : (
+                rolePermissions!.requiresPin.map((action) => (
+                  <li key={action} className="rounded border border-line bg-surface-100 px-3 py-2">
+                    {actionLabels[action]}
+                  </li>
+                ))
+              )}
+            </ul>
+            {rolePermissions && rolePermissions.permittedWithoutPin.length > 0 && (
+              <p className="mt-3 text-xs text-muted">
+                Allowed without PIN: {rolePermissions.permittedWithoutPin.map((action) => actionLabels[action]).join(', ')}
+              </p>
+            )}
+          </div>
+        </Card>
 
         <Card className="space-y-4">
           <h2 className="text-xl font-semibold">Live Preview</h2>

--- a/src/data/mockData.ts
+++ b/src/data/mockData.ts
@@ -30,7 +30,10 @@ export const mockUser: User = {
   name: 'Sarah Johnson',
   role: 'manager',
   storeId: 'store-1',
-  pin: '1234'
+  security: {
+    pinHash: 'e62b3de9cf0f538f34abf4af7d42be1d',
+    pinUpdatedAt: new Date('2024-01-03T10:00:00Z').toISOString()
+  }
 };
 
 export const mockCategories: Category[] = [

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -25,13 +25,36 @@ export interface Store {
   phone: string;
 }
 
+export type RestrictedPosAction = 'void-order' | 'process-refund' | 'manager-discount';
+
+export interface MultifactorState {
+  status: 'disabled' | 'pending' | 'verified';
+  method: 'totp';
+  temporarySecret?: string;
+  previewCodes?: string[];
+  recoveryCodes: string[];
+  expiresAt?: string;
+  lastVerifiedAt?: string;
+}
+
+export interface RolePermissions {
+  role: UserRole;
+  permittedWithoutPin: RestrictedPosAction[];
+  requiresPin: RestrictedPosAction[];
+}
+
+export interface UserSecurityProfile {
+  pinHash?: string;
+  pinUpdatedAt?: string;
+}
+
 export interface User {
   id: string;
   email: string;
   name: string;
   role: UserRole;
   storeId: string;
-  pin?: string;
+  security?: UserSecurityProfile;
   lastLogin?: Date;
 }
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,1 +1,2 @@
 export * from './cn';
+export * from './security';

--- a/src/utils/security.ts
+++ b/src/utils/security.ts
@@ -1,0 +1,98 @@
+const fnvPrime = 0x01000193;
+const fnvOffset = 0x811c9dc5;
+
+const toHex = (value: number) => (value >>> 0).toString(16).padStart(8, '0');
+
+const scramble = (input: string, seed: number) => {
+  let hash = seed >>> 0;
+  for (let index = 0; index < input.length; index += 1) {
+    hash ^= input.charCodeAt(index);
+    hash = Math.imul(hash, fnvPrime);
+  }
+  return hash >>> 0;
+};
+
+const hashSegments = (payload: string, segments = 4) => {
+  const values: number[] = [];
+  let seed = fnvOffset;
+
+  for (let segment = 0; segment < segments; segment += 1) {
+    seed = scramble(`${payload}:${segment}`, seed + segment * 0x9e3779b1);
+    values.push(seed);
+  }
+
+  return values;
+};
+
+/**
+ * Deterministically hashes a PIN with a tenant-specific salt.
+ * The hash is not meant for production security but keeps demo data off plain text.
+ */
+export const hashPin = (pin: string, salt: string) => {
+  const payload = `${pin}:${salt}`;
+  return hashSegments(payload).map(toHex).join('');
+};
+
+export const verifyPinHash = (pin: string, salt: string, hash: string) => {
+  return hashPin(pin, salt) === hash;
+};
+
+const numericHash = (payload: string) => {
+  let hash = 0x9e3779b9;
+  for (let index = 0; index < payload.length; index += 1) {
+    hash = Math.imul(hash ^ payload.charCodeAt(index), 0x85ebca6b);
+    hash ^= hash >>> 16;
+  }
+  return hash >>> 0;
+};
+
+const padCode = (value: number, digits = 6) => value.toString().padStart(digits, '0').slice(-digits);
+
+export const deriveOneTimeCode = (secret: string, counter: number) => {
+  const hash = numericHash(`${secret}:${counter}`);
+  return padCode(hash % 1_000_000);
+};
+
+export const generatePreviewTotpCodes = (secret: string, count = 3) => {
+  const window = Math.floor(Date.now() / 30_000);
+  return Array.from({ length: count }, (_, index) => deriveOneTimeCode(secret, window + index));
+};
+
+export const verifyTotpCode = (secret: string, code: string) => {
+  const trimmed = code.trim();
+  if (trimmed.length !== 6) return false;
+  const window = Math.floor(Date.now() / 30_000);
+  for (let offset = -1; offset <= 1; offset += 1) {
+    if (deriveOneTimeCode(secret, window + offset) === trimmed) {
+      return true;
+    }
+  }
+  return false;
+};
+
+const base32Alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+
+const randomValues = (count: number) => {
+  if (typeof crypto !== 'undefined' && 'getRandomValues' in crypto) {
+    const values = new Uint32Array(count);
+    crypto.getRandomValues(values);
+    return Array.from(values);
+  }
+  return Array.from({ length: count }, () => Math.floor(Math.random() * 0xffffffff));
+};
+
+export const generateTemporarySecret = (length = 16) => {
+  return randomValues(length)
+    .map((value) => base32Alphabet[value % base32Alphabet.length])
+    .join('');
+};
+
+const recoveryAlphabet = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
+
+export const generateRecoveryCodes = (count = 8) => {
+  return Array.from({ length: count }, () => {
+    const values = randomValues(5).map((value) => recoveryAlphabet[value % recoveryAlphabet.length]);
+    const joined = values.join('');
+    return `${joined.slice(0, 3)}-${joined.slice(3)}`.toUpperCase();
+  });
+};


### PR DESCRIPTION
## Summary
- add hashed PIN verification modal for restricted POS actions and surface override feedback
- expand auth store to track role-based restrictions plus MFA enrollment lifecycle utilities
- introduce BackOffice security card for MFA setup, verification, and recovery code rotation

## Testing
- `npm run lint` *(fails: existing lint errors in Portal, PaperShader, StatusIndicator, and themeStore unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68cffb4247a8832694bafec20eab2047