### PR TITLE
feat: add portal metrics hook

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -125,3 +125,15 @@
 - Log any issues needing backend fixes.  
 **Status:** TODO  
 **Log:**  
+
+---
+
+## Agent 19 — Data Plumbing
+**Scope:** Portal analytics, metrics stores, and sync flows.
+**Tasks:**
+- Move Portal summary/quick stats onto shared data sources.
+- Provide refresh cadence controls aligned with offline mode.
+- Surface status, loading, and error handling for metrics consumers.
+**Status:** DONE
+**Log:**
+- Connected Portal metrics to a new `usePortalMetrics` hook backed by mock analytics data with offline-aware refresh logic. Added manual refresh/interval controls in the UI and documented loading/error handling for the summary cards.

--- a/src/components/apps/Portal.tsx
+++ b/src/components/apps/Portal.tsx
@@ -1,13 +1,15 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useMemo, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import { gsap } from 'gsap';
 import * as LucideIcons from 'lucide-react';
+import { formatDistanceToNow } from 'date-fns';
 import { MotionWrapper } from '../ui/MotionWrapper';
 import { useAuthStore } from '../../stores/authStore';
 import { getAvailableApps } from '../../config/apps';
 import { theme } from '../../config/theme';
-import { Card } from '@mas/ui';
+import { Button, Card } from '@mas/ui';
+import { usePortalMetrics } from '../../hooks/usePortalMetrics';
 
 const MotionCard = motion(Card);
 
@@ -15,8 +17,23 @@ export const Portal: React.FC = () => {
   const navigate = useNavigate();
   const { user, tenant } = useAuthStore();
   const gridRef = useRef<HTMLDivElement>(null);
+  const {
+    metrics,
+    isLoading: isMetricsLoading,
+    isRefreshing: isMetricsRefreshing,
+    error: metricsError,
+    lastUpdated,
+    refresh: refreshMetrics,
+    refreshInterval,
+    setRefreshInterval,
+    isOffline
+  } = usePortalMetrics();
 
-  const availableApps = user ? getAvailableApps(user.role) : [];
+  const userRole = user?.role;
+  const availableApps = useMemo(
+    () => (userRole ? getAvailableApps(userRole) : []),
+    [userRole]
+  );
 
   useEffect(() => {
     if (gridRef.current) {
@@ -45,6 +62,46 @@ export const Portal: React.FC = () => {
     navigate(route);
   };
 
+  const currencyFormatter = useMemo(() => {
+    const currency = tenant?.settings?.currency ?? 'USD';
+
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency,
+      maximumFractionDigits: 2
+    });
+  }, [tenant?.settings?.currency]);
+
+  const lastUpdatedLabel = useMemo(() => {
+    if (!lastUpdated) {
+      return 'Waiting for first sync';
+    }
+
+    return `Updated ${formatDistanceToNow(lastUpdated, { addSuffix: true })}`;
+  }, [lastUpdated]);
+
+  const renderMetricValue = (value: string, emphasis?: 'warning' | 'success') => {
+    if (isMetricsLoading && !metricsError && !isOffline) {
+      return <span className="inline-flex h-5 w-16 animate-pulse rounded bg-surface-200" aria-hidden="true" />;
+    }
+
+    if (metricsError && !isOffline) {
+      return <span className="font-medium text-muted">--</span>;
+    }
+
+    let valueClass = 'font-medium';
+
+    if (emphasis === 'warning') {
+      valueClass += ' text-warning';
+    }
+
+    if (emphasis === 'success') {
+      valueClass += ' text-success';
+    }
+
+    return <span className={valueClass}>{value}</span>;
+  };
+
   return (
     <MotionWrapper type="page" className="p-6">
       <div className="max-w-7xl mx-auto">
@@ -57,7 +114,11 @@ export const Portal: React.FC = () => {
 
         <div ref={gridRef} className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
           {availableApps.map((app) => {
-            const IconComponent = (LucideIcons as any)[app.icon] || LucideIcons.Package;
+            const iconLibrary = LucideIcons as Record<
+              string,
+              React.ComponentType<{ size?: number; className?: string }>
+            >;
+            const IconComponent = iconLibrary[app.icon] || LucideIcons.Package;
 
             return (
               <MotionCard
@@ -90,60 +151,140 @@ export const Portal: React.FC = () => {
           })}
         </div>
 
-        <div className="mt-12 grid grid-cols-1 lg:grid-cols-3 gap-6">
-          <Card>
-            <h3 className="font-semibold mb-4">Today&apos;s Summary</h3>
-            <div className="space-y-3">
-              <div className="flex justify-between">
-                <span className="text-muted">Orders</span>
-                <span className="font-medium">24</span>
-              </div>
-              <div className="flex justify-between">
-                <span className="text-muted">Revenue</span>
-                <span className="font-medium">$1,245.50</span>
-              </div>
-              <div className="flex justify-between">
-                <span className="text-muted">Avg. Order</span>
-                <span className="font-medium">$51.90</span>
+        <div className="mt-12 space-y-6">
+          <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+            <div className="space-y-1">
+              <h3 className="text-xl font-semibold">Operational Metrics</h3>
+              <div className="flex items-center gap-2 text-sm text-muted" aria-live="polite">
+                <LucideIcons.Clock className="h-4 w-4" aria-hidden="true" />
+                <span>{lastUpdatedLabel}</span>
               </div>
             </div>
-          </Card>
 
-          <Card>
-            <h3 className="font-semibold mb-4">Quick Stats</h3>
-            <div className="space-y-3">
-              <div className="flex justify-between">
-                <span className="text-muted">Active Tables</span>
-                <span className="font-medium">8/12</span>
-              </div>
-              <div className="flex justify-between">
-                <span className="text-muted">Kitchen Queue</span>
-                <span className="font-medium">3 tickets</span>
-              </div>
-              <div className="flex justify-between">
-                <span className="text-muted">Low Stock Items</span>
-                <span className="font-medium text-warning">5</span>
-              </div>
-            </div>
-          </Card>
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+              <div className="flex items-center gap-2">
+                <label htmlFor="portal-refresh-interval" className="text-sm text-muted">
+                  Auto refresh
+                </label>
+                <select
+                  id="portal-refresh-interval"
+                  className="h-10 rounded-md border border-line bg-surface-100 px-3 text-sm text-ink focus:border-primary-300 focus:outline-none focus:ring-2 focus:ring-primary-500/30"
+                  value={refreshInterval ?? 'off'}
+                  onChange={(event) => {
+                    const { value } = event.target;
 
-          <Card>
-            <h3 className="font-semibold mb-4">Recent Activity</h3>
-            <div className="space-y-3 text-sm">
-              <div className="flex items-center gap-3">
-                <div className="w-2 h-2 rounded-full bg-success" />
-                <span className="text-muted">Order #1234 completed</span>
+                    if (value === 'off') {
+                      setRefreshInterval(null);
+                    } else {
+                      const parsedValue = Number(value);
+                      setRefreshInterval(Number.isNaN(parsedValue) ? null : parsedValue);
+                    }
+                  }}
+                >
+                  <option value="off">Off</option>
+                  <option value={30_000}>30 seconds</option>
+                  <option value={60_000}>1 minute</option>
+                  <option value={300_000}>5 minutes</option>
+                </select>
               </div>
-              <div className="flex items-center gap-3">
-                <div className="w-2 h-2 rounded-full bg-warning" />
-                <span className="text-muted">Table 5 needs attention</span>
-              </div>
-              <div className="flex items-center gap-3">
-                <div className="w-2 h-2 rounded-full bg-primary-500" />
-                <span className="text-muted">New reservation added</span>
-              </div>
+
+              <Button
+                variant="secondary"
+                size="sm"
+                className="justify-center"
+                onClick={() => {
+                  void refreshMetrics();
+                }}
+                disabled={isOffline || isMetricsLoading || isMetricsRefreshing}
+              >
+                {isMetricsLoading || isMetricsRefreshing ? (
+                  <LucideIcons.Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+                ) : (
+                  <LucideIcons.RefreshCcw className="h-4 w-4" aria-hidden="true" />
+                )}
+                <span>{isMetricsLoading || isMetricsRefreshing ? 'Refreshing…' : 'Refresh now'}</span>
+              </Button>
             </div>
-          </Card>
+          </div>
+
+          {metricsError && !isOffline && (
+            <div
+              role="alert"
+              className="rounded-lg border border-danger/40 bg-danger/10 px-4 py-3 text-sm text-danger"
+            >
+              {metricsError}
+            </div>
+          )}
+
+          {isOffline && (
+            <div
+              role="status"
+              className="rounded-lg border border-warning/40 bg-warning/10 px-4 py-3 text-sm text-warning"
+            >
+              Offline mode active. Metrics will sync when connection is restored.
+            </div>
+          )}
+
+          <div className="grid grid-cols-1 gap-6 lg:grid-cols-3" aria-busy={isMetricsLoading}>
+            <Card aria-live="polite">
+              <h3 className="font-semibold mb-4">Today&apos;s Summary</h3>
+              <div className="space-y-3">
+                <div className="flex justify-between">
+                  <span className="text-muted">Orders</span>
+                  {renderMetricValue(metrics.summary.orders.toLocaleString())}
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-muted">Revenue</span>
+                  {renderMetricValue(currencyFormatter.format(metrics.summary.revenue))}
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-muted">Avg. Order</span>
+                  {renderMetricValue(currencyFormatter.format(metrics.summary.averageOrderValue))}
+                </div>
+              </div>
+            </Card>
+
+            <Card aria-live="polite">
+              <h3 className="font-semibold mb-4">Quick Stats</h3>
+              <div className="space-y-3">
+                <div className="flex justify-between">
+                  <span className="text-muted">Active Tables</span>
+                  {renderMetricValue(`${metrics.quickStats.activeTables}/${metrics.quickStats.totalTables}`)}
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-muted">Kitchen Queue</span>
+                  {renderMetricValue(
+                    `${metrics.quickStats.kitchenQueue} ${metrics.quickStats.kitchenQueue === 1 ? 'ticket' : 'tickets'}`
+                  )}
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-muted">Low Stock Items</span>
+                  {renderMetricValue(
+                    metrics.quickStats.lowStockItems.toString(),
+                    metrics.quickStats.lowStockItems > 0 ? 'warning' : 'success'
+                  )}
+                </div>
+              </div>
+            </Card>
+
+            <Card>
+              <h3 className="font-semibold mb-4">Recent Activity</h3>
+              <div className="space-y-3 text-sm">
+                <div className="flex items-center gap-3">
+                  <div className="w-2 h-2 rounded-full bg-success" />
+                  <span className="text-muted">Order #1234 completed</span>
+                </div>
+                <div className="flex items-center gap-3">
+                  <div className="w-2 h-2 rounded-full bg-warning" />
+                  <span className="text-muted">Table 5 needs attention</span>
+                </div>
+                <div className="flex items-center gap-3">
+                  <div className="w-2 h-2 rounded-full bg-primary-500" />
+                  <span className="text-muted">New reservation added</span>
+                </div>
+              </div>
+            </Card>
+          </div>
         </div>
       </div>
     </MotionWrapper>

--- a/src/data/mockPortalAnalytics.ts
+++ b/src/data/mockPortalAnalytics.ts
@@ -1,0 +1,114 @@
+export interface PortalSummaryMetrics {
+  orders: number;
+  revenue: number;
+  averageOrderValue: number;
+}
+
+export interface PortalQuickStats {
+  activeTables: number;
+  totalTables: number;
+  kitchenQueue: number;
+  lowStockItems: number;
+}
+
+export interface PortalMetrics {
+  summary: PortalSummaryMetrics;
+  quickStats: PortalQuickStats;
+}
+
+export interface FetchPortalMetricsOptions {
+  signal?: AbortSignal;
+}
+
+const BASE_METRICS: PortalMetrics = {
+  summary: {
+    orders: 24,
+    revenue: 1245.5,
+    averageOrderValue: 51.9
+  },
+  quickStats: {
+    activeTables: 8,
+    totalTables: 12,
+    kitchenQueue: 3,
+    lowStockItems: 5
+  }
+};
+
+const createAbortError = () => {
+  const error = new Error('Aborted');
+  error.name = 'AbortError';
+  return error;
+};
+
+const delay = (ms: number, signal?: AbortSignal) =>
+  new Promise<void>((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(createAbortError());
+      return;
+    }
+
+    const timeout = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+
+    const onAbort = () => {
+      clearTimeout(timeout);
+      reject(createAbortError());
+    };
+
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
+
+const randomizeMetric = (base: number, variance: number, decimals = 0) => {
+  const offset = (Math.random() * 2 - 1) * variance;
+  const raw = base + offset;
+
+  if (decimals > 0) {
+    const factor = 10 ** decimals;
+    return Math.max(0, Math.round(raw * factor) / factor);
+  }
+
+  return Math.max(0, Math.round(raw));
+};
+
+const clamp = (value: number, min: number, max: number) => Math.min(max, Math.max(min, value));
+
+export const getPortalMetricsSnapshot = (): PortalMetrics => ({
+  summary: { ...BASE_METRICS.summary },
+  quickStats: { ...BASE_METRICS.quickStats }
+});
+
+export const fetchPortalMetrics = async (
+  options: FetchPortalMetricsOptions = {}
+): Promise<PortalMetrics> => {
+  const { signal } = options;
+
+  await delay(450 + Math.random() * 300, signal);
+
+  const baseSummary = BASE_METRICS.summary;
+  const baseQuickStats = BASE_METRICS.quickStats;
+
+  const orders = randomizeMetric(baseSummary.orders, 6);
+  const averageOrderValue = randomizeMetric(baseSummary.averageOrderValue, 5, 2);
+  const revenueMultiplier = 0.92 + Math.random() * 0.16;
+  const revenue = Math.max(0, Number((orders * averageOrderValue * revenueMultiplier).toFixed(2)));
+
+  const activeTables = clamp(randomizeMetric(baseQuickStats.activeTables, 3), 0, baseQuickStats.totalTables);
+  const kitchenQueue = randomizeMetric(baseQuickStats.kitchenQueue, 2);
+  const lowStockItems = randomizeMetric(baseQuickStats.lowStockItems, 3);
+
+  return {
+    summary: {
+      orders,
+      revenue,
+      averageOrderValue
+    },
+    quickStats: {
+      activeTables,
+      totalTables: baseQuickStats.totalTables,
+      kitchenQueue,
+      lowStockItems
+    }
+  };
+};

--- a/src/hooks/usePortalMetrics.ts
+++ b/src/hooks/usePortalMetrics.ts
@@ -1,0 +1,172 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  fetchPortalMetrics,
+  getPortalMetricsSnapshot,
+  PortalMetrics
+} from '../data/mockPortalAnalytics';
+import { useOfflineStore } from '../stores/offlineStore';
+
+const DEFAULT_REFRESH_MS = 60_000;
+
+type LoadTrigger = 'initial' | 'manual' | 'interval';
+
+export interface UsePortalMetricsOptions {
+  autoRefreshMs?: number | null;
+}
+
+export interface UsePortalMetricsResult {
+  metrics: PortalMetrics;
+  isLoading: boolean;
+  isRefreshing: boolean;
+  error: string | null;
+  lastUpdated: Date | null;
+  refresh: () => Promise<void>;
+  refreshInterval: number | null;
+  setRefreshInterval: (interval: number | null) => void;
+  isOffline: boolean;
+}
+
+export const usePortalMetrics = (
+  options: UsePortalMetricsOptions = {}
+): UsePortalMetricsResult => {
+  const { autoRefreshMs } = options;
+  const initialInterval =
+    autoRefreshMs === undefined ? DEFAULT_REFRESH_MS : autoRefreshMs;
+
+  const isOffline = useOfflineStore((state) => state.isOffline);
+  const lastSyncTime = useOfflineStore((state) => state.lastSyncTime);
+
+  const [metrics, setMetrics] = useState<PortalMetrics>(() => getPortalMetricsSnapshot());
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [isRefreshing, setIsRefreshing] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+  const [refreshInterval, setRefreshIntervalState] = useState<number | null>(
+    initialInterval
+  );
+
+  const controllerRef = useRef<AbortController | null>(null);
+  const previousOfflineRef = useRef<boolean>(isOffline);
+
+  const loadMetrics = useCallback(
+    async (trigger: LoadTrigger = 'manual') => {
+      const setPending = trigger === 'initial' ? setIsLoading : setIsRefreshing;
+      setPending(true);
+
+      if (isOffline) {
+        setPending(false);
+        setError('Offline mode: showing cached metrics.');
+        setLastUpdated((prev) => {
+          if (!lastSyncTime) {
+            return prev;
+          }
+
+          if (!prev) {
+            return lastSyncTime;
+          }
+
+          return prev > lastSyncTime ? prev : lastSyncTime;
+        });
+        return;
+      }
+
+      controllerRef.current?.abort();
+      const controller = new AbortController();
+      controllerRef.current = controller;
+
+      try {
+        const data = await fetchPortalMetrics({ signal: controller.signal });
+        setMetrics(data);
+        setLastUpdated(new Date());
+        setError(null);
+      } catch (err) {
+        if ((err as Error).name === 'AbortError') {
+          return;
+        }
+
+        setError('Unable to load portal metrics.');
+      } finally {
+        setPending(false);
+      }
+    },
+    [isOffline, lastSyncTime]
+  );
+
+  const refresh = useCallback(() => loadMetrics('manual'), [loadMetrics]);
+
+  useEffect(() => {
+    void loadMetrics('initial');
+
+    return () => {
+      controllerRef.current?.abort();
+    };
+  }, [loadMetrics]);
+
+  useEffect(() => {
+    if (previousOfflineRef.current && !isOffline) {
+      void refresh();
+    }
+
+    previousOfflineRef.current = isOffline;
+  }, [isOffline, refresh]);
+
+  useEffect(() => {
+    if (isOffline) {
+      controllerRef.current?.abort();
+      setIsLoading(false);
+      setIsRefreshing(false);
+      setError('Offline mode: showing cached metrics.');
+      setLastUpdated((prev) => {
+        if (!lastSyncTime) {
+          return prev;
+        }
+
+        if (!prev) {
+          return lastSyncTime;
+        }
+
+        return prev > lastSyncTime ? prev : lastSyncTime;
+      });
+    }
+  }, [isOffline, lastSyncTime]);
+
+  useEffect(() => {
+    if (refreshInterval === null || refreshInterval <= 0 || isOffline) {
+      return;
+    }
+
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const id = window.setInterval(() => {
+      void loadMetrics('interval');
+    }, refreshInterval);
+
+    return () => {
+      window.clearInterval(id);
+    };
+  }, [refreshInterval, isOffline, loadMetrics]);
+
+  useEffect(() => {
+    if (autoRefreshMs !== undefined) {
+      setRefreshIntervalState(autoRefreshMs);
+    }
+  }, [autoRefreshMs]);
+
+  const updateRefreshInterval = useCallback((interval: number | null) => {
+    setRefreshIntervalState(interval);
+  }, []);
+
+  return {
+    metrics,
+    isLoading,
+    isRefreshing,
+    error,
+    lastUpdated,
+    refresh,
+    refreshInterval,
+    setRefreshInterval: updateRefreshInterval,
+    isOffline
+  };
+};


### PR DESCRIPTION
## Summary
- add a usePortalMetrics hook that hydrates from mock analytics data and pauses refreshes when offline
- replace portal summary and quick stats cards with hook-driven values plus loading, error, and manual refresh controls
- document the new data plumbing workflow in Agent 19's log entry

## Testing
- npm run lint *(fails: existing lint errors in unrelated legacy files)*

------
https://chatgpt.com/codex/tasks/task_e_68cffb3c85ac8326ac9881ecb154a47c