### PR TITLE
Add calendar app experience

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -118,10 +118,23 @@
 ---
 
 ## Agent 10 — Database/Functionality Checks
-**Scope:** Ensure functional logic and DB integration still work after UI changes.  
-**Tasks:**  
-- Verify forms still submit correctly.  
-- Confirm API/data fetching unaffected.  
-- Log any issues needing backend fixes.  
-**Status:** TODO  
-**Log:**  
+**Scope:** Ensure functional logic and DB integration still work after UI changes.
+**Tasks:**
+- Verify forms still submit correctly.
+- Confirm API/data fetching unaffected.
+- Log any issues needing backend fixes.
+**Status:** TODO
+**Log:**
+
+---
+
+## Agent 17 — Calendar Experience
+**Scope:** Calendar scheduling UI, reservations, and shift coordination.
+**Tasks:**
+- Build interactive calendar with week/month views.
+- Surface reservation details and waitlist status.
+- Visualise tables/resources with drag-ready layout.
+- Summarise shift tasks and leadership coverage.
+**Status:** DONE
+**Log:**
+- Implemented CalendarApp with MotionWrapper fallbacks for reduced motion, week/month toggles, and reservation board fed by new mockCalendar data; connected `/calendar` route and added drag-ready floor grid with MAS palette status badges.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { Login } from './components/auth/Login';
 import { Portal } from './components/apps/Portal';
 import { POS } from './components/apps/POS';
 import { BackOffice } from './components/apps/BackOffice';
+import { CalendarApp } from './components/apps/calendar/CalendarApp';
 import { useAuthStore } from './stores/authStore';
 import { useOfflineStore } from './stores/offlineStore';
 
@@ -16,7 +17,6 @@ const Inventory = () => <motion.div initial={{ opacity: 0 }} animate={{ opacity:
 const Customers = () => <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="p-6"><h2 className="text-2xl font-bold">Customer Management</h2><p className="text-muted mt-2">Coming soon...</p></motion.div>;
 const Promotions = () => <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="p-6"><h2 className="text-2xl font-bold">Promotions</h2><p className="text-muted mt-2">Coming soon...</p></motion.div>;
 const Reports = () => <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="p-6"><h2 className="text-2xl font-bold">Reports & Analytics</h2><p className="text-muted mt-2">Coming soon...</p></motion.div>;
-const Calendar = () => <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="p-6"><h2 className="text-2xl font-bold">Calendar & Reservations</h2><p className="text-muted mt-2">Coming soon...</p></motion.div>;
 const Accounting = () => <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="p-6"><h2 className="text-2xl font-bold">Accounting</h2><p className="text-muted mt-2">Coming soon...</p></motion.div>;
 
 function App() {
@@ -63,7 +63,7 @@ function App() {
           <Route path="customers" element={<Customers />} />
           <Route path="promotions" element={<Promotions />} />
           <Route path="reports" element={<Reports />} />
-          <Route path="calendar" element={<Calendar />} />
+          <Route path="calendar" element={<CalendarApp />} />
           <Route path="accounting" element={<Accounting />} />
           <Route path="backoffice" element={<BackOffice />} />
         </Route>

--- a/src/components/apps/calendar/CalendarApp.tsx
+++ b/src/components/apps/calendar/CalendarApp.tsx
@@ -1,0 +1,480 @@
+import React, { useMemo, useState } from 'react';
+import { useReducedMotion } from 'framer-motion';
+import {
+  CalendarDays,
+  Clock,
+  LayoutGrid,
+  ListChecks,
+  Users,
+  UserCheck
+} from 'lucide-react';
+import { Button, Card } from '@mas/ui';
+import { MotionWrapper } from '../../ui/MotionWrapper';
+import { cn } from '../../../utils/cn';
+import {
+  mockCalendar,
+  CalendarDaySummary,
+  CalendarReservation,
+  CalendarTableBlock,
+  CalendarTask,
+  CalendarWeekSlot,
+  ReservationStatus,
+  TaskStatus,
+  OccupancyState,
+  TableStatus
+} from '../../../data/mockCalendar';
+
+const reservationBadgeStyles: Record<ReservationStatus, string> = {
+  confirmed:
+    'bg-[rgba(238,118,109,0.12)] text-[#EE766D] border border-[#EE766D]/40',
+  seated: 'bg-[#24242E] text-white',
+  completed: 'bg-[#D6D6D6] text-[#24242E]',
+  cancelled: 'border border-[#EE766D] text-[#EE766D] bg-white',
+  waitlist: 'bg-[rgba(214,214,214,0.45)] text-[#24242E] border border-[#D6D6D6]'
+};
+
+const occupancyStyles: Record<OccupancyState, string> = {
+  light: 'bg-[rgba(214,214,214,0.28)] text-[#24242E] border border-[#D6D6D6]',
+  steady: 'bg-[rgba(238,118,109,0.15)] text-[#EE766D] border border-[#EE766D]/40',
+  peak: 'bg-[#EE766D] text-white border border-[#EE766D]'
+};
+
+const tableStatusStyles: Record<TableStatus, string> = {
+  available: 'bg-white border border-dashed border-[#D6D6D6] text-[#24242E]',
+  reserved: 'bg-[#EE766D] text-white shadow-sm',
+  seated: 'bg-[#24242E] text-white shadow-sm',
+  cleaning: 'bg-[rgba(214,214,214,0.6)] text-[#24242E] border border-[#D6D6D6]'
+};
+
+const taskStatusAccent: Record<TaskStatus, string> = {
+  open: 'text-[#EE766D]',
+  'in-progress': 'text-[#24242E]',
+  done: 'text-[#D6D6D6] line-through'
+};
+
+const occupancyFill: Record<OccupancyState, string> = {
+  light: '#D6D6D6',
+  steady: '#24242E',
+  peak: '#EE766D'
+};
+
+export const CalendarApp: React.FC = () => {
+  const [viewMode, setViewMode] = useState<'week' | 'month'>('week');
+  const [selectedDate, setSelectedDate] = useState<string>(mockCalendar.currentDate);
+  const shouldReduceMotion = useReducedMotion();
+
+  const daySummary = useMemo<CalendarDaySummary | undefined>(
+    () => mockCalendar.monthDays.find((day) => day.date === selectedDate),
+    [selectedDate]
+  );
+
+  const reservations = useMemo<CalendarReservation[]>(
+    () => mockCalendar.reservations.filter((reservation) => reservation.date === selectedDate),
+    [selectedDate]
+  );
+
+  const waitlistCount = reservations.filter((reservation) => reservation.status === 'waitlist').length;
+
+  const content = (
+    <div className="space-y-8">
+      <div className="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+        <div className="space-y-1">
+          <h1 className="text-3xl font-semibold text-[#24242E]">Calendar &amp; Reservations</h1>
+          <p className="text-sm text-[#24242E]/70 max-w-2xl">
+            Live overview of reservations, floor availability, and shift tasks for
+            {` ${mockCalendar.currentWeekRange}.`}
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Button
+            variant={viewMode === 'week' ? 'primary' : 'outline'}
+            onClick={() => setViewMode('week')}
+            className="min-w-[112px]"
+          >
+            Week view
+          </Button>
+          <Button
+            variant={viewMode === 'month' ? 'primary' : 'outline'}
+            onClick={() => setViewMode('month')}
+            className="min-w-[112px]"
+          >
+            Month view
+          </Button>
+        </div>
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+        <SummaryTile
+          icon={CalendarDays}
+          label="Reservations"
+          value={mockCalendar.summary.reservations.toString()}
+          hint="Booked for the week"
+        />
+        <SummaryTile
+          icon={Users}
+          label="Covers"
+          value={mockCalendar.summary.covers.toString()}
+          hint="Expected guests"
+        />
+        <SummaryTile
+          icon={Clock}
+          label="Waitlist"
+          value={mockCalendar.summary.waitlist.toString()}
+          hint="Guests awaiting slots"
+        />
+        <SummaryTile
+          icon={UserCheck}
+          label="Special events"
+          value={mockCalendar.summary.events.toString()}
+          hint="Live music &amp; VIP"
+        />
+      </div>
+
+      <div className="grid gap-6 xl:grid-cols-[minmax(0,2.4fr)_minmax(0,1fr)]">
+        <div className="space-y-6">
+          <Card className="space-y-6">
+            <header className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <p className="text-sm font-medium text-[#24242E]/70">{selectedDate}</p>
+                <h2 className="text-2xl font-semibold text-[#24242E]">
+                  {daySummary?.dayLabel ?? 'Selected day'} overview
+                </h2>
+              </div>
+              {daySummary && (
+                <div
+                  className={cn(
+                    'inline-flex items-center gap-2 rounded-full px-3 py-1 text-sm font-medium',
+                    occupancyStyles[daySummary.occupancy]
+                  )}
+                >
+                  <span className="inline-flex h-2 w-2 rounded-full bg-white/80" aria-hidden />
+                  {daySummary.occupancy === 'peak'
+                    ? 'Peak demand'
+                    : daySummary.occupancy === 'steady'
+                    ? 'Steady flow'
+                    : 'Light service'}
+                </div>
+              )}
+            </header>
+
+            {viewMode === 'week' ? (
+              <WeekOccupancy slots={mockCalendar.weekSlots} />
+            ) : (
+              <MonthGrid
+                days={mockCalendar.monthDays}
+                selectedDate={selectedDate}
+                onSelectDate={setSelectedDate}
+              />
+            )}
+          </Card>
+
+          <Card className="space-y-5">
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <h3 className="text-xl font-semibold text-[#24242E]">Reservation board</h3>
+                <p className="text-sm text-[#24242E]/70">
+                  {reservations.length} reservations · {waitlistCount} waitlist entries
+                </p>
+              </div>
+              <Button variant="outline" className="flex items-center gap-2">
+                <LayoutGrid size={16} />
+                Manage tables
+              </Button>
+            </div>
+
+            <ReservationList reservations={reservations} />
+          </Card>
+
+          <Card className="space-y-4">
+            <div className="flex items-center justify-between">
+              <h3 className="text-xl font-semibold text-[#24242E]">Floor availability</h3>
+              <span className="text-xs font-medium uppercase tracking-wide text-[#24242E]/60">
+                Drag-ready layout
+              </span>
+            </div>
+            <TableGrid tables={mockCalendar.tables} />
+          </Card>
+        </div>
+
+        <div className="space-y-6">
+          <Card className="space-y-4">
+            <div className="flex items-center justify-between">
+              <h3 className="text-xl font-semibold text-[#24242E]">Shift tasks</h3>
+              <ListChecks className="text-[#EE766D]" size={18} aria-hidden />
+            </div>
+            <TaskList tasks={mockCalendar.tasks} />
+          </Card>
+
+          <Card className="space-y-4">
+            <h3 className="text-xl font-semibold text-[#24242E]">Leadership coverage</h3>
+            <ul className="space-y-3">
+              {mockCalendar.shifts.map((shift) => (
+                <li
+                  key={shift.label}
+                  className="rounded-lg border border-[#D6D6D6] bg-white p-4"
+                >
+                  <p className="text-sm font-semibold text-[#24242E]">{shift.label}</p>
+                  <p className="text-xs text-[#24242E]/70">{shift.start} – {shift.end}</p>
+                  <p className="mt-2 text-sm text-[#24242E]">
+                    <span className="font-medium">{shift.lead}</span>
+                    {`: ${shift.focus}`}
+                  </p>
+                </li>
+              ))}
+            </ul>
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+
+  if (shouldReduceMotion) {
+    return <div className="p-6">{content}</div>;
+  }
+
+  return (
+    <MotionWrapper type="page" className="p-6">
+      {content}
+    </MotionWrapper>
+  );
+};
+
+interface SummaryTileProps {
+  icon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
+  label: string;
+  value: string;
+  hint: string;
+}
+
+const SummaryTile: React.FC<SummaryTileProps> = ({ icon: Icon, label, value, hint }) => {
+  return (
+    <div className="rounded-xl border border-[#D6D6D6] bg-white p-4 shadow-sm">
+      <div className="flex items-center justify-between">
+        <div>
+          <p className="text-sm font-medium text-[#24242E]/70">{label}</p>
+          <p className="text-2xl font-semibold text-[#24242E]">{value}</p>
+        </div>
+        <span className="flex h-10 w-10 items-center justify-center rounded-full bg-[rgba(238,118,109,0.12)] text-[#EE766D]">
+          <Icon size={18} aria-hidden />
+        </span>
+      </div>
+      <p className="mt-3 text-xs text-[#24242E]/60">{hint}</p>
+    </div>
+  );
+};
+
+interface MonthGridProps {
+  days: CalendarDaySummary[];
+  selectedDate: string;
+  onSelectDate: (date: string) => void;
+}
+
+const MonthGrid: React.FC<MonthGridProps> = ({ days, selectedDate, onSelectDate }) => {
+  return (
+    <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
+      {days.map((day) => {
+        const isSelected = day.date === selectedDate;
+        return (
+          <button
+            key={day.date}
+            type="button"
+            onClick={() => onSelectDate(day.date)}
+            className={cn(
+              'group rounded-xl border bg-white p-4 text-left shadow-sm transition focus:outline-none focus-visible:ring-2 focus-visible:ring-[#EE766D]/40',
+              isSelected ? 'border-[#EE766D] shadow-md' : 'border-[#D6D6D6] hover:border-[#EE766D]/40'
+            )}
+          >
+            <div className="flex items-center justify-between">
+              <p className="text-sm font-medium text-[#24242E]">{day.dayLabel}</p>
+              {day.isToday && (
+                <span className="rounded-full bg-[#EE766D] px-2 py-0.5 text-xs font-semibold text-white">
+                  Today
+                </span>
+              )}
+            </div>
+            <p className="mt-3 text-2xl font-semibold text-[#24242E]">{day.reservations}</p>
+            <p className="text-xs text-[#24242E]/60">Reservations</p>
+            <div
+              className={cn(
+                'mt-4 inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-medium',
+                occupancyStyles[day.occupancy]
+              )}
+            >
+              <span className="inline-flex h-1.5 w-1.5 rounded-full bg-white/80" aria-hidden />
+              {day.occupancy === 'peak' ? 'Peak' : day.occupancy === 'steady' ? 'Steady' : 'Light'}
+            </div>
+          </button>
+        );
+      })}
+    </div>
+  );
+};
+
+const WeekOccupancy: React.FC<{ slots: CalendarWeekSlot[] }> = ({ slots }) => {
+  return (
+    <div className="space-y-4">
+      {slots.map((slot) => (
+        <div key={slot.time} className="space-y-1">
+          <div className="flex items-center justify-between text-sm">
+            <span className="font-medium text-[#24242E]">{slot.time}</span>
+            <span className="text-[#24242E]/60">{slot.covers} covers</span>
+          </div>
+          <div className="h-3 rounded-full bg-[rgba(214,214,214,0.35)]">
+            <div
+              className="h-full rounded-full"
+              style={{
+                width: `${Math.min(100, slot.occupancy * 100)}%`,
+                backgroundColor: occupancyFill[slot.status]
+              }}
+            />
+          </div>
+          {slot.note && <p className="text-xs text-[#24242E]/60">{slot.note}</p>}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+const ReservationList: React.FC<{ reservations: CalendarReservation[] }> = ({ reservations }) => {
+  if (!reservations.length) {
+    return (
+      <p className="rounded-lg border border-dashed border-[#D6D6D6] bg-white p-6 text-center text-sm text-[#24242E]/60">
+        No reservations scheduled for this day.
+      </p>
+    );
+  }
+
+  return (
+    <ul className="space-y-4">
+      {reservations.map((reservation) => (
+        <li
+          key={reservation.id}
+          className="rounded-xl border border-[#D6D6D6] bg-white p-4 shadow-sm transition hover:shadow-md"
+        >
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <div className="space-y-2">
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="text-lg font-semibold text-[#24242E]">
+                  {reservation.guestName}
+                </span>
+                {reservation.tags?.map((tag) => (
+                  <span
+                    key={tag}
+                    className="rounded-full bg-[rgba(238,118,109,0.12)] px-2 py-0.5 text-xs font-medium text-[#EE766D]"
+                  >
+                    {tag}
+                  </span>
+                ))}
+              </div>
+              <div className="flex flex-wrap items-center gap-3 text-sm text-[#24242E]/70">
+                <span className="inline-flex items-center gap-1">
+                  <Clock size={14} aria-hidden />
+                  {reservation.time}
+                </span>
+                <span className="inline-flex items-center gap-1">
+                  <Users size={14} aria-hidden />
+                  {reservation.partySize} guests
+                </span>
+                <span className="inline-flex items-center gap-1">
+                  <LayoutGrid size={14} aria-hidden />
+                  {reservation.table}
+                </span>
+                <span className="inline-flex items-center gap-1">
+                  <CalendarDays size={14} aria-hidden />
+                  {reservation.duration} min stay
+                </span>
+              </div>
+              {reservation.notes && (
+                <p className="text-sm text-[#24242E]">{reservation.notes}</p>
+              )}
+            </div>
+            <span
+              className={cn(
+                'self-start rounded-full px-3 py-1 text-sm font-medium',
+                reservationBadgeStyles[reservation.status]
+              )}
+            >
+              {reservation.status === 'confirmed'
+                ? 'Confirmed'
+                : reservation.status === 'seated'
+                ? 'Seated'
+                : reservation.status === 'completed'
+                ? 'Completed'
+                : reservation.status === 'cancelled'
+                ? 'Cancelled'
+                : 'Waitlist'}
+            </span>
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+const TableGrid: React.FC<{ tables: CalendarTableBlock[] }> = ({ tables }) => {
+  return (
+    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      {tables.map((table) => {
+        const isDark = table.status === 'reserved' || table.status === 'seated';
+        const mutedText = isDark ? 'text-white/70' : 'text-[#24242E]/70';
+        const accentText = isDark ? 'text-white' : 'text-[#24242E]';
+
+        return (
+          <div
+            key={table.id}
+            draggable
+            tabIndex={0}
+            aria-label={`${table.label} seats ${table.capacity} guests, status ${table.status}`}
+            className={cn(
+              'cursor-grab rounded-xl p-4 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-[#EE766D]/40 active:cursor-grabbing',
+              tableStatusStyles[table.status]
+            )}
+          >
+            <div className="flex items-center justify-between">
+              <p className={cn('text-lg font-semibold', accentText)}>{table.label}</p>
+              <span
+                className={cn(
+                  'text-xs uppercase tracking-wide',
+                  isDark ? 'text-white/70' : 'text-[#24242E]/60'
+                )}
+              >
+                {table.location}
+              </span>
+            </div>
+            <p className={cn('mt-2 text-sm', mutedText)}>Seats {table.capacity}</p>
+            {table.upcomingReservation && (
+              <p className={cn('mt-3 text-sm', accentText)}>{table.upcomingReservation}</p>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+const TaskList: React.FC<{ tasks: CalendarTask[] }> = ({ tasks }) => {
+  return (
+    <ul className="space-y-3">
+      {tasks.map((task) => (
+        <li
+          key={task.id}
+          className="rounded-lg border border-[#D6D6D6] bg-white p-4 shadow-sm"
+        >
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <p className={cn('text-sm font-semibold text-[#24242E]', taskStatusAccent[task.status])}>
+                {task.title}
+              </p>
+              <p className="mt-1 text-xs text-[#24242E]/70">
+                Due {task.due} · {task.assignedTo}
+              </p>
+            </div>
+            <span className="rounded-full bg-[rgba(238,118,109,0.12)] px-2 py-0.5 text-xs font-medium uppercase tracking-wide text-[#EE766D]">
+              {task.category}
+            </span>
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+};

--- a/src/data/mockCalendar.ts
+++ b/src/data/mockCalendar.ts
@@ -1,0 +1,330 @@
+export type ReservationStatus =
+  | 'confirmed'
+  | 'seated'
+  | 'completed'
+  | 'cancelled'
+  | 'waitlist';
+
+export type TableStatus = 'available' | 'reserved' | 'seated' | 'cleaning';
+
+export type OccupancyState = 'light' | 'steady' | 'peak';
+
+export type TaskStatus = 'open' | 'in-progress' | 'done';
+
+export interface CalendarReservation {
+  id: string;
+  date: string;
+  time: string;
+  guestName: string;
+  partySize: number;
+  status: ReservationStatus;
+  table: string;
+  duration: number;
+  tags?: string[];
+  notes?: string;
+}
+
+export interface CalendarTableBlock {
+  id: string;
+  label: string;
+  capacity: number;
+  status: TableStatus;
+  location: 'main' | 'patio' | 'bar';
+  upcomingReservation?: string;
+}
+
+export interface CalendarTask {
+  id: string;
+  title: string;
+  due: string;
+  assignedTo: string;
+  status: TaskStatus;
+  category: 'reservations' | 'guests' | 'operations';
+}
+
+export interface CalendarDaySummary {
+  date: string;
+  dayLabel: string;
+  coverCount: number;
+  reservations: number;
+  occupancy: OccupancyState;
+  isToday?: boolean;
+}
+
+export interface CalendarWeekSlot {
+  time: string;
+  occupancy: number;
+  covers: number;
+  status: OccupancyState;
+  note?: string;
+}
+
+export interface CalendarShift {
+  label: string;
+  start: string;
+  end: string;
+  lead: string;
+  focus: string;
+}
+
+export interface CalendarMockData {
+  currentDate: string;
+  currentWeekRange: string;
+  summary: {
+    reservations: number;
+    covers: number;
+    waitlist: number;
+    events: number;
+  };
+  monthDays: CalendarDaySummary[];
+  weekSlots: CalendarWeekSlot[];
+  reservations: CalendarReservation[];
+  tables: CalendarTableBlock[];
+  tasks: CalendarTask[];
+  shifts: CalendarShift[];
+}
+
+export const mockCalendar: CalendarMockData = {
+  currentDate: '2024-06-12',
+  currentWeekRange: 'June 10 – June 16, 2024',
+  summary: {
+    reservations: 42,
+    covers: 186,
+    waitlist: 5,
+    events: 2
+  },
+  monthDays: [
+    { date: '2024-06-02', dayLabel: 'Sun', coverCount: 94, reservations: 28, occupancy: 'steady' },
+    { date: '2024-06-03', dayLabel: 'Mon', coverCount: 58, reservations: 18, occupancy: 'light' },
+    { date: '2024-06-04', dayLabel: 'Tue', coverCount: 74, reservations: 22, occupancy: 'steady' },
+    { date: '2024-06-05', dayLabel: 'Wed', coverCount: 112, reservations: 34, occupancy: 'peak' },
+    { date: '2024-06-06', dayLabel: 'Thu', coverCount: 128, reservations: 37, occupancy: 'peak' },
+    { date: '2024-06-07', dayLabel: 'Fri', coverCount: 162, reservations: 44, occupancy: 'peak' },
+    { date: '2024-06-08', dayLabel: 'Sat', coverCount: 178, reservations: 49, occupancy: 'peak' },
+    { date: '2024-06-09', dayLabel: 'Sun', coverCount: 96, reservations: 30, occupancy: 'steady' },
+    { date: '2024-06-10', dayLabel: 'Mon', coverCount: 62, reservations: 20, occupancy: 'light' },
+    { date: '2024-06-11', dayLabel: 'Tue', coverCount: 80, reservations: 24, occupancy: 'steady' },
+    {
+      date: '2024-06-12',
+      dayLabel: 'Wed',
+      coverCount: 118,
+      reservations: 36,
+      occupancy: 'peak',
+      isToday: true
+    },
+    { date: '2024-06-13', dayLabel: 'Thu', coverCount: 130, reservations: 38, occupancy: 'peak' },
+    { date: '2024-06-14', dayLabel: 'Fri', coverCount: 168, reservations: 47, occupancy: 'peak' },
+    { date: '2024-06-15', dayLabel: 'Sat', coverCount: 182, reservations: 50, occupancy: 'peak' },
+    { date: '2024-06-16', dayLabel: 'Sun', coverCount: 102, reservations: 31, occupancy: 'steady' }
+  ],
+  weekSlots: [
+    { time: '17:00', occupancy: 0.45, covers: 24, status: 'steady', note: 'Early diners & pre-show' },
+    { time: '18:00', occupancy: 0.72, covers: 36, status: 'peak' },
+    { time: '19:00', occupancy: 0.86, covers: 44, status: 'peak', note: 'Most tables turning over' },
+    { time: '20:00', occupancy: 0.78, covers: 38, status: 'peak' },
+    { time: '21:00', occupancy: 0.54, covers: 28, status: 'steady' },
+    { time: '22:00', occupancy: 0.32, covers: 16, status: 'light', note: 'Late bar seating' }
+  ],
+  reservations: [
+    {
+      id: 'res-101',
+      date: '2024-06-12',
+      time: '17:30',
+      guestName: 'Alex Morgan',
+      partySize: 4,
+      status: 'confirmed',
+      table: 'T12',
+      duration: 90,
+      tags: ['Anniversary'],
+      notes: 'Prefers a quieter corner table.'
+    },
+    {
+      id: 'res-102',
+      date: '2024-06-12',
+      time: '18:00',
+      guestName: 'Priya Desai',
+      partySize: 2,
+      status: 'seated',
+      table: 'T6',
+      duration: 75,
+      tags: ['VIP']
+    },
+    {
+      id: 'res-103',
+      date: '2024-06-12',
+      time: '18:30',
+      guestName: 'Liam Chen',
+      partySize: 6,
+      status: 'confirmed',
+      table: 'T18',
+      duration: 120,
+      notes: 'Cake arrival at 19:15.'
+    },
+    {
+      id: 'res-104',
+      date: '2024-06-12',
+      time: '19:15',
+      guestName: 'Jordan Smith',
+      partySize: 3,
+      status: 'waitlist',
+      table: 'T9',
+      duration: 90,
+      tags: ['Allergy: nuts']
+    },
+    {
+      id: 'res-105',
+      date: '2024-06-12',
+      time: '19:45',
+      guestName: 'Martinez Family',
+      partySize: 5,
+      status: 'confirmed',
+      table: 'T2',
+      duration: 105
+    },
+    {
+      id: 'res-106',
+      date: '2024-06-12',
+      time: '20:15',
+      guestName: 'Sofia Alvarez',
+      partySize: 2,
+      status: 'completed',
+      table: 'Bar 2',
+      duration: 60
+    },
+    {
+      id: 'res-107',
+      date: '2024-06-12',
+      time: '21:00',
+      guestName: 'Noah Williams',
+      partySize: 2,
+      status: 'cancelled',
+      table: 'T5',
+      duration: 60,
+      notes: 'Cancelled at 15:20, deposit refunded.'
+    }
+  ],
+  tables: [
+    {
+      id: 'tbl-1',
+      label: 'T1',
+      capacity: 2,
+      status: 'available',
+      location: 'main',
+      upcomingReservation: 'Hold for walk-in couples.'
+    },
+    {
+      id: 'tbl-2',
+      label: 'T2',
+      capacity: 5,
+      status: 'reserved',
+      location: 'main',
+      upcomingReservation: 'Martinez Family at 19:45'
+    },
+    {
+      id: 'tbl-3',
+      label: 'T4',
+      capacity: 4,
+      status: 'seated',
+      location: 'main',
+      upcomingReservation: 'Priya Desai — seated 18:00'
+    },
+    {
+      id: 'tbl-4',
+      label: 'T6',
+      capacity: 2,
+      status: 'seated',
+      location: 'patio',
+      upcomingReservation: 'Dessert fire at 18:45'
+    },
+    {
+      id: 'tbl-5',
+      label: 'T8',
+      capacity: 4,
+      status: 'reserved',
+      location: 'patio',
+      upcomingReservation: 'Liam Chen at 18:30'
+    },
+    {
+      id: 'tbl-6',
+      label: 'T10',
+      capacity: 6,
+      status: 'available',
+      location: 'main',
+      upcomingReservation: 'Open for waitlist at 19:15'
+    },
+    {
+      id: 'tbl-7',
+      label: 'T12',
+      capacity: 4,
+      status: 'reserved',
+      location: 'bar',
+      upcomingReservation: 'Anniversary setup by 17:20'
+    },
+    {
+      id: 'tbl-8',
+      label: 'Bar 2',
+      capacity: 2,
+      status: 'cleaning',
+      location: 'bar',
+      upcomingReservation: 'Turn table by 20:45'
+    }
+  ],
+  tasks: [
+    {
+      id: 'task-1',
+      title: 'Confirm 10pax corporate booking for Friday',
+      due: '15:00',
+      assignedTo: 'Jamie',
+      status: 'in-progress',
+      category: 'reservations'
+    },
+    {
+      id: 'task-2',
+      title: 'Prepare anniversary dessert plate for T12',
+      due: '17:15',
+      assignedTo: 'Ana',
+      status: 'open',
+      category: 'guests'
+    },
+    {
+      id: 'task-3',
+      title: 'Update patio heating schedule',
+      due: '18:30',
+      assignedTo: 'Chris',
+      status: 'done',
+      category: 'operations'
+    },
+    {
+      id: 'task-4',
+      title: 'Call waitlist for 19:15 slot',
+      due: '18:45',
+      assignedTo: 'Taylor',
+      status: 'open',
+      category: 'reservations'
+    },
+    {
+      id: 'task-5',
+      title: 'Verify band setup checklist',
+      due: '19:30',
+      assignedTo: 'Morgan',
+      status: 'in-progress',
+      category: 'operations'
+    }
+  ],
+  shifts: [
+    {
+      label: 'Service Lead',
+      start: '16:00',
+      end: '00:00',
+      lead: 'Morgan Blake',
+      focus: 'Monitor VIP experiences & live music guests.'
+    },
+    {
+      label: 'Floor Supervisor',
+      start: '16:30',
+      end: '23:00',
+      lead: 'Taylor Ray',
+      focus: 'Coordinate table turns and walk-in traffic.'
+    }
+  ]
+};


### PR DESCRIPTION
## Summary
- build the calendar experience with MotionWrapper safeguards, week/month switching, reservation board, and drag-ready floor grid using MAS palette accents
- introduce dedicated mock calendar data powering reservations, tables, and tasks
- point the /calendar route at the new app and record the update for Agent 17

## Testing
- npm run lint *(fails: existing lint violations in pre-existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68cffb3a591c83269973d40d56a057f0