### PR TITLE
Add customers dashboard and POS customer linking

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -118,10 +118,22 @@
 ---
 
 ## Agent 10 — Database/Functionality Checks
-**Scope:** Ensure functional logic and DB integration still work after UI changes.  
-**Tasks:**  
-- Verify forms still submit correctly.  
-- Confirm API/data fetching unaffected.  
-- Log any issues needing backend fixes.  
-**Status:** TODO  
-**Log:**  
+**Scope:** Ensure functional logic and DB integration still work after UI changes.
+**Tasks:**
+- Verify forms still submit correctly.
+- Confirm API/data fetching unaffected.
+- Log any issues needing backend fixes.
+**Status:** TODO
+**Log:**
+
+---
+
+## Agent 14 — Customers
+**Scope:** Customers dashboard, data seeding, POS customer linking.
+**Tasks:**
+- Implement CRM dashboard views (profiles, loyalty, credit, gift cards).
+- Seed customer mock data with loyalty balances and histories.
+- Expose selectors and integrate POS customer picker.
+**Status:** DONE
+**Log:**
+- Implemented tabbed Customers dashboard with animated detail drawers, seeded loyalty/credit/gift card data, and wired POS picker modal using shared selectors; no blocking issues.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { Login } from './components/auth/Login';
 import { Portal } from './components/apps/Portal';
 import { POS } from './components/apps/POS';
 import { BackOffice } from './components/apps/BackOffice';
+import { CustomersDashboard } from './components/apps/customers/CustomersDashboard';
 import { useAuthStore } from './stores/authStore';
 import { useOfflineStore } from './stores/offlineStore';
 
@@ -13,7 +14,6 @@ import { useOfflineStore } from './stores/offlineStore';
 const KDS = () => <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="p-6"><h2 className="text-2xl font-bold">Kitchen Display System</h2><p className="text-muted mt-2">Coming soon...</p></motion.div>;
 const Products = () => <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="p-6"><h2 className="text-2xl font-bold">Product Catalog</h2><p className="text-muted mt-2">Coming soon...</p></motion.div>;
 const Inventory = () => <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="p-6"><h2 className="text-2xl font-bold">Inventory Management</h2><p className="text-muted mt-2">Coming soon...</p></motion.div>;
-const Customers = () => <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="p-6"><h2 className="text-2xl font-bold">Customer Management</h2><p className="text-muted mt-2">Coming soon...</p></motion.div>;
 const Promotions = () => <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="p-6"><h2 className="text-2xl font-bold">Promotions</h2><p className="text-muted mt-2">Coming soon...</p></motion.div>;
 const Reports = () => <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="p-6"><h2 className="text-2xl font-bold">Reports & Analytics</h2><p className="text-muted mt-2">Coming soon...</p></motion.div>;
 const Calendar = () => <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="p-6"><h2 className="text-2xl font-bold">Calendar & Reservations</h2><p className="text-muted mt-2">Coming soon...</p></motion.div>;
@@ -60,7 +60,7 @@ function App() {
           <Route path="kds" element={<KDS />} />
           <Route path="products" element={<Products />} />
           <Route path="inventory" element={<Inventory />} />
-          <Route path="customers" element={<Customers />} />
+          <Route path="customers" element={<CustomersDashboard />} />
           <Route path="promotions" element={<Promotions />} />
           <Route path="reports" element={<Reports />} />
           <Route path="calendar" element={<Calendar />} />

--- a/src/components/apps/POS.tsx
+++ b/src/components/apps/POS.tsx
@@ -6,26 +6,30 @@ import { MotionWrapper, AnimatedList } from '../ui/MotionWrapper';
 import { useCartStore } from '../../stores/cartStore';
 import { useOfflineStore } from '../../stores/offlineStore';
 import { useAuthStore } from '../../stores/authStore';
-import { Product, Category } from '../../types';
+import { Product, Category, Customer } from '../../types';
 import { mockProducts, mockCategories } from '../../data/mockData';
+import { CustomerPickerModal } from './customers/CustomerPickerModal';
 
 export const POS: React.FC = () => {
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedCategory, setSelectedCategory] = useState<string>('all');
   const [products] = useState<Product[]>(mockProducts);
   const [categories] = useState<Category[]>(mockCategories);
+  const [isCustomerPickerOpen, setCustomerPickerOpen] = useState(false);
   const gridRef = useRef<HTMLDivElement>(null);
   
   const { 
     items, 
-    subtotal, 
-    tax, 
-    total, 
+    subtotal,
+    tax,
+    total,
     orderType,
-    addItem, 
-    updateItemQuantity, 
+    customer,
+    addItem,
+    updateItemQuantity,
     removeItem,
-    setOrderType 
+    setOrderType,
+    setCustomer
   } = useCartStore();
   
   const { queueOrder } = useOfflineStore();
@@ -71,6 +75,7 @@ export const POS: React.FC = () => {
       userId: user.id,
       type: orderType,
       status: 'confirmed' as const,
+      customerId: customer?.id,
       lines: items.map(item => ({
         id: item.id,
         productId: item.productId,
@@ -133,6 +138,48 @@ export const POS: React.FC = () => {
                   Takeaway
                 </button>
               </div>
+            </div>
+
+            <div className="space-y-3">
+              <button
+                type="button"
+                onClick={() => setCustomerPickerOpen(true)}
+                className={`flex w-full items-center gap-2 rounded-lg border px-3 py-2 text-left text-sm font-medium transition hover:border-[#EE766D] hover:bg-[#EE766D]/10 ${
+                  customer ? 'border-[#EE766D] bg-[#EE766D]/10 text-[#24242E]' : 'border-line text-[#24242E]'
+                }`}
+              >
+                <User size={16} />
+                {customer ? `Linked: ${customer.name}` : 'Link customer'}
+              </button>
+
+              {customer && (
+                <div className="rounded-lg border border-line bg-surface-200 p-3 text-sm">
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <p className="font-semibold text-[#24242E]">{customer.name}</p>
+                      <p className="text-xs text-muted">
+                        {customer.loyaltyPoints} pts • Credit ${customer.storeCreditBalance.toFixed(2)}
+                      </p>
+                      {customer.tags && customer.tags.length > 0 && (
+                        <div className="mt-2 flex flex-wrap gap-2 text-[11px]">
+                          {customer.tags.map(tag => (
+                            <span key={tag} className="rounded-full bg-[#D6D6D6]/60 px-2.5 py-1 text-[#24242E]">
+                              {tag}
+                            </span>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => setCustomer(null)}
+                      className="rounded-full border border-line px-3 py-1 text-xs font-medium text-muted transition hover:border-[#EE766D] hover:text-[#EE766D]"
+                    >
+                      Clear
+                    </button>
+                  </div>
+                </div>
+              )}
             </div>
           </div>
 
@@ -320,6 +367,14 @@ export const POS: React.FC = () => {
           </div>
         </div>
       </div>
+      <CustomerPickerModal
+        isOpen={isCustomerPickerOpen}
+        onClose={() => setCustomerPickerOpen(false)}
+        onSelect={(selected: Customer) => {
+          setCustomer(selected);
+          setCustomerPickerOpen(false);
+        }}
+      />
     </MotionWrapper>
   );
 };

--- a/src/components/apps/customers/CustomerPickerModal.tsx
+++ b/src/components/apps/customers/CustomerPickerModal.tsx
@@ -1,0 +1,134 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { Search, UserRound, X } from 'lucide-react';
+
+import { MotionWrapper } from '../../ui/MotionWrapper';
+import { Customer } from '../../../types';
+import { getCustomerById, useCustomerProfiles } from '../../../data/mockCustomers';
+
+interface CustomerPickerModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSelect: (customer: Customer) => void;
+}
+
+export const CustomerPickerModal: React.FC<CustomerPickerModalProps> = ({ isOpen, onClose, onSelect }) => {
+  const [search, setSearch] = useState('');
+  const profiles = useCustomerProfiles(search);
+
+  useEffect(() => {
+    if (isOpen) {
+      setSearch('');
+    }
+  }, [isOpen]);
+
+  const sortedProfiles = useMemo(
+    () =>
+      profiles.slice().sort((a, b) => {
+        const aScore = a.loyaltyPoints + a.storeCreditBalance;
+        const bScore = b.loyaltyPoints + b.storeCreditBalance;
+        return bScore - aScore;
+      }),
+    [profiles],
+  );
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4 py-10">
+      <div className="absolute inset-0" aria-hidden onClick={onClose} />
+      <MotionWrapper
+        type="modal"
+        className="relative z-10 w-full max-w-2xl rounded-2xl border border-[#D6D6D6]/80 bg-surface-100 p-6 shadow-modal"
+      >
+        <header className="mb-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h2 className="text-xl font-semibold text-[#24242E]">Link a customer</h2>
+            <p className="text-sm text-muted">
+              Search loyalty members to attach them to the order for points and rewards.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="self-end rounded-full border border-[#D6D6D6] p-2 text-[#24242E] transition hover:bg-[#EE766D] hover:text-white"
+            aria-label="Close customer picker"
+          >
+            <X size={18} />
+          </button>
+        </header>
+
+        <div className="relative mb-5">
+          <Search size={18} className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-[#24242E]/50" />
+          <input
+            type="search"
+            value={search}
+            onChange={(event) => setSearch(event.target.value)}
+            className="w-full rounded-full border border-[#D6D6D6] bg-white py-2 pl-10 pr-4 text-sm text-[#24242E] shadow-sm transition focus:border-[#EE766D] focus:ring-2 focus:ring-[#EE766D]/30"
+            placeholder="Search by name, phone, or tags"
+            autoFocus
+          />
+        </div>
+
+        <div className="max-h-80 overflow-y-auto">
+          {sortedProfiles.length === 0 ? (
+            <div className="flex flex-col items-center justify-center gap-3 rounded-xl border border-dashed border-[#D6D6D6] bg-surface-200/60 py-12 text-center text-sm text-muted">
+              <UserRound size={28} className="text-[#EE766D]" />
+              <div>
+                <p>No customers match that search.</p>
+                <p className="text-xs">Try searching for a different spelling or tag.</p>
+              </div>
+            </div>
+          ) : (
+            <ul className="space-y-3">
+              {sortedProfiles.map((profile) => {
+                const customer = getCustomerById(profile.id);
+                if (!customer) return null;
+
+                return (
+                  <li key={profile.id}>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        onSelect(customer);
+                        onClose();
+                      }}
+                      className="w-full rounded-xl border border-[#D6D6D6]/70 bg-white px-4 py-3 text-left transition hover:border-[#EE766D] hover:bg-[#EE766D]/10"
+                    >
+                      <div className="flex flex-wrap items-center justify-between gap-3">
+                        <div>
+                          <p className="text-base font-semibold text-[#24242E]">{profile.name}</p>
+                          <p className="text-xs text-muted">
+                            {profile.email || 'No email'}
+                            {profile.phone && <span className="ml-2">• {profile.phone}</span>}
+                          </p>
+                        </div>
+                        <div className="text-right">
+                          <p className="text-sm font-semibold text-[#24242E]">{profile.loyaltyPoints} pts</p>
+                          <p className="text-xs text-muted">Credit {profile.storeCreditBalance.toFixed(2)}</p>
+                        </div>
+                      </div>
+                      {profile.tags.length > 0 && (
+                        <div className="mt-3 flex flex-wrap gap-2 text-xs">
+                          {profile.tags.map((tag) => (
+                            <span
+                              key={tag}
+                              className="rounded-full bg-[#D6D6D6]/60 px-3 py-1 text-[#24242E]"
+                            >
+                              {tag}
+                            </span>
+                          ))}
+                        </div>
+                      )}
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
+      </MotionWrapper>
+    </div>
+  );
+};
+
+export default CustomerPickerModal;

--- a/src/components/apps/customers/CustomersDashboard.tsx
+++ b/src/components/apps/customers/CustomersDashboard.tsx
@@ -1,0 +1,835 @@
+import React, { useMemo, useState } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import {
+  ArrowRight,
+  Gift,
+  Search,
+  Sparkles,
+  UserRound,
+  Users,
+  Wallet2,
+  X,
+} from 'lucide-react';
+import { format, formatDistanceToNow } from 'date-fns';
+import { Card } from '@mas/ui';
+
+import { MotionWrapper } from '../../ui/MotionWrapper';
+import {
+  CustomerLoyaltySummary,
+  CustomerProfileSummary,
+  CustomerStoreCreditSummary,
+  GiftCardSummary,
+  mockCustomers,
+  useCustomerById,
+  useCustomerProfiles,
+  useGiftCardDetails,
+  useGiftCardSummaries,
+  useLoyaltyAccounts,
+  useStoreCreditAccounts,
+  useVisitHistory,
+} from '../../../data/mockCustomers';
+
+type ActiveTab = 'profiles' | 'loyalty' | 'credit' | 'giftCards';
+
+type DrawerState =
+  | { type: 'profiles'; customerId: string }
+  | { type: 'loyalty'; customerId: string }
+  | { type: 'credit'; customerId: string }
+  | { type: 'gift'; customerId: string; giftCode: string };
+
+const ACCENT = '#EE766D';
+
+const currencyFormatter = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+  minimumFractionDigits: 2,
+});
+
+const formatDate = (value?: string) => {
+  if (!value) return '—';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return '—';
+  return format(date, 'MMM d, yyyy');
+};
+
+const formatDateTime = (value?: string) => {
+  if (!value) return '—';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return '—';
+  return format(date, 'MMM d, yyyy • h:mm a');
+};
+
+const formatRelative = (value?: string) => {
+  if (!value) return undefined;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return undefined;
+  return formatDistanceToNow(date, { addSuffix: true });
+};
+
+const TabButton: React.FC<{
+  label: string;
+  icon: React.ReactNode;
+  isActive: boolean;
+  onClick: () => void;
+}> = ({ label, icon, isActive, onClick }) => (
+  <button
+    type="button"
+    aria-pressed={isActive}
+    onClick={onClick}
+    className={`inline-flex items-center gap-2 rounded-full border px-4 py-2 text-sm font-medium transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 ${
+      isActive
+        ? 'border-transparent bg-[#EE766D] text-white shadow-sm'
+        : 'border-[#D6D6D6] text-[#24242E] hover:border-transparent hover:bg-[#EE766D]/10'
+    }`}
+  >
+    <span className="text-base">{icon}</span>
+    <span>{label}</span>
+  </button>
+);
+
+const StatusPill: React.FC<{ label: string; tone?: 'neutral' | 'success' | 'danger' | 'accent' } & React.HTMLAttributes<HTMLSpanElement>> = ({
+  label,
+  tone = 'neutral',
+  className = '',
+  ...props
+}) => {
+  const toneStyles: Record<typeof tone, string> = {
+    neutral: 'bg-[#D6D6D6]/60 text-[#24242E]',
+    success: 'bg-success/10 text-success',
+    danger: 'bg-danger/10 text-danger',
+    accent: 'bg-[#EE766D]/15 text-[#EE766D]',
+  } as const;
+
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-3 py-1 text-xs font-medium ${toneStyles[tone]} ${className}`.trim()}
+      {...props}
+    >
+      {label}
+    </span>
+  );
+};
+
+const metricCards = [
+  { key: 'customers', label: 'Total Customers', icon: <Users size={18} />, accent: ACCENT },
+  { key: 'loyalty', label: 'Loyalty Points', icon: <Sparkles size={18} />, accent: '#FFB347' },
+  { key: 'credit', label: 'Store Credit', icon: <Wallet2 size={18} />, accent: '#7AC4A8' },
+  { key: 'giftcards', label: 'Gift Card Balance', icon: <Gift size={18} />, accent: '#9A9AD6' },
+] as const;
+
+export const CustomersDashboard: React.FC = () => {
+  const [activeTab, setActiveTab] = useState<ActiveTab>('profiles');
+  const [searchTerm, setSearchTerm] = useState('');
+  const [drawer, setDrawer] = useState<DrawerState | null>(null);
+
+  const profileSummaries = useCustomerProfiles(searchTerm);
+  const loyaltySummaries = useLoyaltyAccounts(searchTerm);
+  const creditSummaries = useStoreCreditAccounts(searchTerm);
+  const giftCardSummaries = useGiftCardSummaries(searchTerm);
+
+  const selectedCustomer = useCustomerById(drawer ? drawer.customerId : null);
+  const visitHistory = useVisitHistory(drawer ? drawer.customerId : null);
+  const giftCardDetails = useGiftCardDetails(drawer?.type === 'gift' ? drawer.giftCode : null);
+
+  const totals = useMemo(() => {
+    const totalCustomers = mockCustomers.length;
+    const totalLoyaltyPoints = mockCustomers.reduce((sum, customer) => sum + customer.loyaltyPoints, 0);
+    const totalCredit = mockCustomers.reduce(
+      (sum, customer) => sum + customer.storeCredits.reduce((creditSum, credit) => creditSum + credit.balance, 0),
+      0,
+    );
+    const totalGiftBalance = mockCustomers.reduce(
+      (sum, customer) => sum + customer.giftCards.reduce((cardSum, card) => cardSum + card.balance, 0),
+      0,
+    );
+    const visitsLast30 = mockCustomers
+      .flatMap((customer) => customer.visits)
+      .filter((visit) => {
+        const date = new Date(visit.date);
+        if (Number.isNaN(date.getTime())) return false;
+        const now = new Date();
+        const diff = now.getTime() - date.getTime();
+        const thirtyDays = 30 * 24 * 60 * 60 * 1000;
+        return diff <= thirtyDays;
+      }).length;
+
+    return {
+      totalCustomers,
+      totalLoyaltyPoints,
+      totalCredit,
+      totalGiftBalance,
+      visitsLast30,
+    };
+  }, []);
+
+  const openDrawer = (state: DrawerState) => setDrawer(state);
+  const closeDrawer = () => setDrawer(null);
+
+  const renderProfiles = (rows: CustomerProfileSummary[]) => (
+    <Card className="border border-[#D6D6D6]/70 bg-surface-100 shadow-sm">
+      {rows.length === 0 ? (
+        <div className="flex min-h-[200px] flex-col items-center justify-center gap-2 text-center text-sm text-muted">
+          <UserRound size={28} className="text-[#EE766D]" />
+          <p>No customer profiles match that search yet.</p>
+          <p className="text-xs text-muted">Try searching by name, email, phone, or tag.</p>
+        </div>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="min-w-full text-left text-sm">
+            <thead className="border-b border-[#D6D6D6] text-xs uppercase tracking-wide text-[#24242E]/70">
+              <tr>
+                <th className="px-4 py-3 font-semibold">Customer</th>
+                <th className="px-4 py-3 font-semibold">Visits</th>
+                <th className="px-4 py-3 font-semibold">Last Visit</th>
+                <th className="px-4 py-3 font-semibold">Loyalty</th>
+                <th className="px-4 py-3 font-semibold">Lifetime Spend</th>
+                <th className="px-4 py-3" aria-label="Inspect" />
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-[#D6D6D6]/60">
+              {rows.map((profile) => (
+                <tr
+                  key={profile.id}
+                  className="transition-colors hover:bg-[#EE766D]/10 focus-within:bg-[#EE766D]/15"
+                >
+                  <td className="px-4 py-3">
+                    <div className="font-semibold text-[#24242E]">{profile.name}</div>
+                    <div className="text-xs text-muted">
+                      {profile.email || 'No email on file'}
+                      {profile.phone && <span className="ml-2">• {profile.phone}</span>}
+                    </div>
+                    <div className="mt-2 flex flex-wrap gap-2">
+                      {profile.tags.map((tag) => (
+                        <StatusPill key={tag} label={tag} tone="neutral" />
+                      ))}
+                    </div>
+                  </td>
+                  <td className="px-4 py-3">
+                    <div className="font-semibold text-[#24242E]">{profile.totalVisits}</div>
+                    <div className="text-xs text-muted">avg spend {currencyFormatter.format(profile.averageSpend)}</div>
+                  </td>
+                  <td className="px-4 py-3">
+                    <div className="font-medium text-[#24242E]">{formatDate(profile.lastVisit)}</div>
+                    {formatRelative(profile.lastVisit) && (
+                      <div className="text-xs text-muted">{formatRelative(profile.lastVisit)}</div>
+                    )}
+                  </td>
+                  <td className="px-4 py-3">
+                    <div className="font-semibold text-[#24242E]">{profile.loyaltyPoints} pts</div>
+                    <StatusPill label={profile.loyaltyTier} tone="accent" />
+                  </td>
+                  <td className="px-4 py-3 font-semibold text-[#24242E]">
+                    {currencyFormatter.format(profile.lifetimeSpend)}
+                  </td>
+                  <td className="px-4 py-3 text-right">
+                    <button
+                      type="button"
+                      onClick={() => openDrawer({ type: 'profiles', customerId: profile.id })}
+                      className="inline-flex items-center gap-1 text-sm font-medium text-[#EE766D] transition hover:text-[#D3544C]"
+                    >
+                      Inspect
+                      <ArrowRight size={16} />
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </Card>
+  );
+
+  const renderLoyalty = (rows: CustomerLoyaltySummary[]) => (
+    <Card className="border border-[#D6D6D6]/70 bg-surface-100 shadow-sm">
+      {rows.length === 0 ? (
+        <div className="flex min-h-[200px] flex-col items-center justify-center gap-2 text-sm text-muted">
+          <Sparkles size={28} className="text-[#EE766D]" />
+          <p>No loyalty accounts found for that filter.</p>
+        </div>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="min-w-full text-left text-sm">
+            <thead className="border-b border-[#D6D6D6] text-xs uppercase tracking-wide text-[#24242E]/70">
+              <tr>
+                <th className="px-4 py-3 font-semibold">Member</th>
+                <th className="px-4 py-3 font-semibold">Tier</th>
+                <th className="px-4 py-3 font-semibold">Points</th>
+                <th className="px-4 py-3 font-semibold">Next Reward</th>
+                <th className="px-4 py-3 font-semibold">Next Expiration</th>
+                <th className="px-4 py-3" aria-label="Inspect" />
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-[#D6D6D6]/60">
+              {rows.map((account) => (
+                <tr key={account.customerId} className="transition-colors hover:bg-[#EE766D]/10">
+                  <td className="px-4 py-3">
+                    <div className="font-semibold text-[#24242E]">{account.name}</div>
+                    {account.lastEarnedOn && (
+                      <div className="text-xs text-muted">Earned {formatRelative(account.lastEarnedOn)}</div>
+                    )}
+                  </td>
+                  <td className="px-4 py-3">
+                    <StatusPill label={account.tier} tone="accent" />
+                  </td>
+                  <td className="px-4 py-3">
+                    <div className="font-semibold text-[#24242E]">{account.points} pts</div>
+                    <div className="text-xs text-muted">Lifetime {account.lifetimePoints.toLocaleString()} pts</div>
+                  </td>
+                  <td className="px-4 py-3 font-medium text-[#24242E]">
+                    {account.pointsToNextReward} pts
+                  </td>
+                  <td className="px-4 py-3">
+                    <div className="font-medium text-[#24242E]">
+                      {account.nextExpiration ? formatDate(account.nextExpiration) : '—'}
+                    </div>
+                    {account.expiringPoints && (
+                      <div className="text-xs text-muted">{account.expiringPoints} pts at risk</div>
+                    )}
+                  </td>
+                  <td className="px-4 py-3 text-right">
+                    <button
+                      type="button"
+                      onClick={() => openDrawer({ type: 'loyalty', customerId: account.customerId })}
+                      className="inline-flex items-center gap-1 text-sm font-medium text-[#EE766D] transition hover:text-[#D3544C]"
+                    >
+                      View history
+                      <ArrowRight size={16} />
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </Card>
+  );
+
+  const renderCredit = (rows: CustomerStoreCreditSummary[]) => (
+    <Card className="border border-[#D6D6D6]/70 bg-surface-100 shadow-sm">
+      {rows.length === 0 ? (
+        <div className="flex min-h-[200px] flex-col items-center justify-center gap-2 text-sm text-muted">
+          <Wallet2 size={28} className="text-[#EE766D]" />
+          <p>No store credit balances in this filter.</p>
+        </div>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="min-w-full text-left text-sm">
+            <thead className="border-b border-[#D6D6D6] text-xs uppercase tracking-wide text-[#24242E]/70">
+              <tr>
+                <th className="px-4 py-3 font-semibold">Customer</th>
+                <th className="px-4 py-3 font-semibold">Available Credit</th>
+                <th className="px-4 py-3 font-semibold">Accounts</th>
+                <th className="px-4 py-3 font-semibold">Next Expiration</th>
+                <th className="px-4 py-3" aria-label="Inspect" />
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-[#D6D6D6]/60">
+              {rows.map((account) => (
+                <tr key={account.customerId} className="transition-colors hover:bg-[#EE766D]/10">
+                  <td className="px-4 py-3">
+                    <div className="font-semibold text-[#24242E]">{account.name}</div>
+                    {account.lastUsedOn && (
+                      <div className="text-xs text-muted">Last used {formatRelative(account.lastUsedOn)}</div>
+                    )}
+                  </td>
+                  <td className="px-4 py-3 font-semibold text-[#24242E]">
+                    {currencyFormatter.format(account.totalBalance)}
+                  </td>
+                  <td className="px-4 py-3">
+                    <StatusPill label={`${account.accountCount} ledger${account.accountCount === 1 ? '' : 's'}`} />
+                  </td>
+                  <td className="px-4 py-3">
+                    <div className="font-medium text-[#24242E]">
+                      {account.nextExpirationDate ? formatDate(account.nextExpirationDate) : '—'}
+                    </div>
+                    {account.nextExpirationAmount !== undefined && (
+                      <div className="text-xs text-muted">
+                        {currencyFormatter.format(account.nextExpirationAmount)} at risk
+                      </div>
+                    )}
+                  </td>
+                  <td className="px-4 py-3 text-right">
+                    <button
+                      type="button"
+                      onClick={() => openDrawer({ type: 'credit', customerId: account.customerId })}
+                      className="inline-flex items-center gap-1 text-sm font-medium text-[#EE766D] transition hover:text-[#D3544C]"
+                    >
+                      Ledger
+                      <ArrowRight size={16} />
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </Card>
+  );
+
+  const renderGiftCards = (rows: GiftCardSummary[]) => (
+    <Card className="border border-[#D6D6D6]/70 bg-surface-100 shadow-sm">
+      {rows.length === 0 ? (
+        <div className="flex min-h-[200px] flex-col items-center justify-center gap-2 text-sm text-muted">
+          <Gift size={28} className="text-[#EE766D]" />
+          <p>No gift cards found for that search.</p>
+        </div>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="min-w-full text-left text-sm">
+            <thead className="border-b border-[#D6D6D6] text-xs uppercase tracking-wide text-[#24242E]/70">
+              <tr>
+                <th className="px-4 py-3 font-semibold">Card</th>
+                <th className="px-4 py-3 font-semibold">Customer</th>
+                <th className="px-4 py-3 font-semibold">Balance</th>
+                <th className="px-4 py-3 font-semibold">Status</th>
+                <th className="px-4 py-3 font-semibold">Expires</th>
+                <th className="px-4 py-3" aria-label="Inspect" />
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-[#D6D6D6]/60">
+              {rows.map((card) => (
+                <tr key={card.code} className="transition-colors hover:bg-[#EE766D]/10">
+                  <td className="px-4 py-3 font-semibold text-[#24242E]">{card.code}</td>
+                  <td className="px-4 py-3">
+                    <div className="font-semibold text-[#24242E]">{card.customerName}</div>
+                    {card.lastUsedOn && (
+                      <div className="text-xs text-muted">Used {formatRelative(card.lastUsedOn)}</div>
+                    )}
+                  </td>
+                  <td className="px-4 py-3 font-semibold text-[#24242E]">
+                    {currencyFormatter.format(card.balance)}
+                    <div className="text-xs text-muted">
+                      of {currencyFormatter.format(card.originalValue)}
+                    </div>
+                  </td>
+                  <td className="px-4 py-3">
+                    <StatusPill
+                      label={card.status === 'active' ? 'Active' : card.status === 'redeemed' ? 'Redeemed' : 'Void'}
+                      tone={
+                        card.status === 'active'
+                          ? 'accent'
+                          : card.status === 'redeemed'
+                          ? 'neutral'
+                          : 'danger'
+                      }
+                    />
+                  </td>
+                  <td className="px-4 py-3 font-medium text-[#24242E]">
+                    {card.expiresOn ? formatDate(card.expiresOn) : 'No expiry'}
+                  </td>
+                  <td className="px-4 py-3 text-right">
+                    <button
+                      type="button"
+                      onClick={() => openDrawer({ type: 'gift', customerId: card.customerId, giftCode: card.code })}
+                      className="inline-flex items-center gap-1 text-sm font-medium text-[#EE766D] transition hover:text-[#D3544C]"
+                    >
+                      Details
+                      <ArrowRight size={16} />
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </Card>
+  );
+
+  const renderDrawerContent = () => {
+    if (!drawer || !selectedCustomer) return null;
+
+    if (drawer.type === 'profiles') {
+      return (
+        <div className="space-y-6">
+          <div>
+            <h3 className="text-lg font-semibold text-[#24242E]">Customer Profile</h3>
+            <p className="text-sm text-muted">{selectedCustomer.notes || 'No notes on file.'}</p>
+          </div>
+
+          <div className="grid grid-cols-1 gap-4 text-sm">
+            <div className="rounded-xl border border-[#D6D6D6]/80 bg-white p-4">
+              <h4 className="mb-2 text-xs font-semibold uppercase tracking-wide text-[#24242E]/70">Contact</h4>
+              <p className="font-medium text-[#24242E]">{selectedCustomer.name}</p>
+              <p className="text-muted">{selectedCustomer.email || 'No email provided'}</p>
+              <p className="text-muted">{selectedCustomer.phone || 'No phone provided'}</p>
+              {selectedCustomer.birthday && (
+                <p className="mt-2 text-muted">Birthday • {formatDate(selectedCustomer.birthday)}</p>
+              )}
+            </div>
+
+            <div className="rounded-xl border border-[#D6D6D6]/80 bg-white p-4">
+              <h4 className="mb-2 text-xs font-semibold uppercase tracking-wide text-[#24242E]/70">Loyalty Snapshot</h4>
+              <p className="text-2xl font-semibold text-[#24242E]">{selectedCustomer.loyaltyPoints} pts</p>
+              <p className="text-sm text-muted">
+                Tier {selectedCustomer.loyalty.tier} • {selectedCustomer.loyalty.pointsToNextReward} pts to next reward
+              </p>
+              {selectedCustomer.loyalty.expiring && selectedCustomer.loyalty.expiring.length > 0 && (
+                <p className="mt-2 text-xs text-[#EE766D]">
+                  {selectedCustomer.loyalty.expiring[0].points} pts expire {formatRelative(selectedCustomer.loyalty.expiring[0].expiresOn)}
+                </p>
+              )}
+            </div>
+          </div>
+
+          <div>
+            <h4 className="mb-3 text-sm font-semibold text-[#24242E]">Recent Visits</h4>
+            <ul className="space-y-3 text-sm">
+              {visitHistory.slice(0, 6).map((visit) => (
+                <li
+                  key={visit.orderId}
+                  className="rounded-xl border border-[#D6D6D6]/70 bg-surface-100 px-4 py-3"
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <p className="font-semibold text-[#24242E]">
+                        {formatDateTime(visit.date)} • {visit.channel.replace('-', ' ')}
+                      </p>
+                      <p className="text-xs text-muted">Order {visit.orderId}</p>
+                    </div>
+                    <div className="text-right">
+                      <p className="font-semibold text-[#24242E]">{currencyFormatter.format(visit.totalSpend)}</p>
+                      <p className="text-xs text-muted">{visit.pointsEarned} pts earned</p>
+                    </div>
+                  </div>
+                </li>
+              ))}
+              {visitHistory.length === 0 && <li className="text-sm text-muted">No visits recorded yet.</li>}
+            </ul>
+          </div>
+        </div>
+      );
+    }
+
+    if (drawer.type === 'loyalty') {
+      return (
+        <div className="space-y-6">
+          <div>
+            <h3 className="text-lg font-semibold text-[#24242E]">Loyalty History</h3>
+            <p className="text-sm text-muted">Track accruals, redemptions, and adjustments.</p>
+          </div>
+
+          <div className="rounded-xl border border-[#D6D6D6]/80 bg-white p-4 text-sm">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-wide text-[#24242E]/70">Current balance</p>
+                <p className="text-2xl font-semibold text-[#24242E]">{selectedCustomer.loyaltyPoints} pts</p>
+              </div>
+              <StatusPill label={selectedCustomer.loyalty.tier} tone="accent" />
+            </div>
+            <p className="mt-3 text-sm text-muted">
+              {selectedCustomer.loyalty.pointsToNextReward} pts to next reward • Lifetime {selectedCustomer.loyalty.lifetimePoints.toLocaleString()} pts
+            </p>
+          </div>
+
+          <div>
+            <h4 className="mb-3 text-sm font-semibold text-[#24242E]">Expiring Balances</h4>
+            <div className="space-y-2 text-sm">
+              {selectedCustomer.loyalty.expiring?.length ? (
+                selectedCustomer.loyalty.expiring.map((entry) => (
+                  <div
+                    key={`${entry.points}-${entry.expiresOn}`}
+                    className="flex items-center justify-between rounded-xl border border-[#D6D6D6]/80 bg-surface-100 px-4 py-3"
+                  >
+                    <span className="font-medium text-[#24242E]">{entry.points} pts</span>
+                    <span className="text-sm text-muted">{formatDate(entry.expiresOn)}</span>
+                  </div>
+                ))
+              ) : (
+                <p className="text-sm text-muted">No expirations scheduled.</p>
+              )}
+            </div>
+          </div>
+
+          <div>
+            <h4 className="mb-3 text-sm font-semibold text-[#24242E]">Ledger</h4>
+            <ul className="space-y-3 text-sm">
+              {selectedCustomer.loyalty.history.slice().reverse().map((entry) => (
+                <li key={entry.id} className="rounded-xl border border-[#D6D6D6]/70 bg-surface-100 px-4 py-3">
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <p className="font-semibold text-[#24242E]">{formatDateTime(entry.date)}</p>
+                      <p className="text-xs text-muted">{entry.reference || 'Manual entry'}</p>
+                      {entry.note && <p className="text-xs text-muted">{entry.note}</p>}
+                    </div>
+                    <div className="text-right">
+                      <p className={`font-semibold ${entry.points >= 0 ? 'text-success' : 'text-danger'}`}>
+                        {entry.points >= 0 ? '+' : ''}
+                        {entry.points} pts
+                      </p>
+                      <p className="text-xs text-muted">Balance {entry.balanceAfter} pts</p>
+                    </div>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      );
+    }
+
+    if (drawer.type === 'credit') {
+      return (
+        <div className="space-y-6 text-sm">
+          <div>
+            <h3 className="text-lg font-semibold text-[#24242E]">Store Credit Accounts</h3>
+            <p className="text-sm text-muted">Track issued balances, expirations, and usage.</p>
+          </div>
+
+          {selectedCustomer.storeCredits.length === 0 ? (
+            <p className="text-sm text-muted">No store credit accounts for this customer.</p>
+          ) : (
+            selectedCustomer.storeCredits.map((credit) => (
+              <div key={credit.id} className="rounded-xl border border-[#D6D6D6]/70 bg-surface-100 p-4">
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <p className="text-xs font-semibold uppercase tracking-wide text-[#24242E]/70">Balance</p>
+                    <p className="text-xl font-semibold text-[#24242E]">{currencyFormatter.format(credit.balance)}</p>
+                    <p className="text-xs text-muted">Issued {formatDate(credit.issuedOn)}</p>
+                  </div>
+                  <div className="text-right">
+                    <p className="text-xs font-semibold uppercase tracking-wide text-[#24242E]/70">Expires</p>
+                    <p className="text-sm font-medium text-[#24242E]">
+                      {credit.expiresOn ? formatDate(credit.expiresOn) : 'No expiry'}
+                    </p>
+                    {credit.expiresOn && <p className="text-xs text-muted">{formatRelative(credit.expiresOn)}</p>}
+                  </div>
+                </div>
+
+                <div className="mt-4 space-y-2">
+                  <h5 className="text-xs font-semibold uppercase tracking-wide text-[#24242E]/70">Ledger</h5>
+                  {credit.ledger.map((entry) => (
+                    <div
+                      key={entry.id}
+                      className="flex items-start justify-between rounded-lg border border-[#D6D6D6]/60 bg-white px-3 py-2"
+                    >
+                      <div>
+                        <p className="text-sm font-medium text-[#24242E]">{formatDateTime(entry.date)}</p>
+                        <p className="text-xs text-muted">{entry.reference || 'Adjustment'}</p>
+                        {entry.note && <p className="text-xs text-muted">{entry.note}</p>}
+                      </div>
+                      <div className="text-right">
+                        <p className={`text-sm font-semibold ${entry.amount >= 0 ? 'text-success' : 'text-danger'}`}>
+                          {entry.amount >= 0 ? '+' : ''}
+                          {currencyFormatter.format(entry.amount)}
+                        </p>
+                        <p className="text-xs text-muted">Balance {currencyFormatter.format(entry.balanceAfter)}</p>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ))
+          )}
+        </div>
+      );
+    }
+
+    if (drawer.type === 'gift' && giftCardDetails) {
+      const { card, customer } = giftCardDetails;
+      return (
+        <div className="space-y-6 text-sm">
+          <div>
+            <h3 className="text-lg font-semibold text-[#24242E]">Gift Card Details</h3>
+            <p className="text-sm text-muted">{card.code} • Issued to {customer.name}</p>
+          </div>
+
+          <div className="rounded-xl border border-[#D6D6D6]/70 bg-surface-100 p-4">
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-wide text-[#24242E]/70">Balance</p>
+                <p className="text-xl font-semibold text-[#24242E]">{currencyFormatter.format(card.balance)}</p>
+                <p className="text-xs text-muted">Original {currencyFormatter.format(card.originalValue)}</p>
+              </div>
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-wide text-[#24242E]/70">Status</p>
+                <StatusPill
+                  label={card.status === 'active' ? 'Active' : card.status === 'redeemed' ? 'Redeemed' : 'Void'}
+                  tone={card.status === 'active' ? 'accent' : card.status === 'redeemed' ? 'neutral' : 'danger'}
+                />
+                <p className="mt-2 text-xs text-muted">
+                  {card.expiresOn ? `Expires ${formatDate(card.expiresOn)}` : 'No expiration'}
+                </p>
+              </div>
+            </div>
+          </div>
+
+          <div>
+            <h4 className="mb-3 text-sm font-semibold text-[#24242E]">Transactions</h4>
+            <ul className="space-y-3">
+              {card.transactions.map((entry) => (
+                <li key={entry.id} className="rounded-xl border border-[#D6D6D6]/60 bg-white px-4 py-3">
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <p className="font-semibold text-[#24242E]">{formatDateTime(entry.date)}</p>
+                      <p className="text-xs text-muted">{entry.reference || 'Adjustment'}</p>
+                      {entry.note && <p className="text-xs text-muted">{entry.note}</p>}
+                    </div>
+                    <div className="text-right">
+                      <p className={`text-sm font-semibold ${entry.amount >= 0 ? 'text-success' : 'text-danger'}`}>
+                        {entry.amount >= 0 ? '+' : ''}
+                        {currencyFormatter.format(entry.amount)}
+                      </p>
+                      <p className="text-xs text-muted">Balance {currencyFormatter.format(entry.balanceAfter)}</p>
+                    </div>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      );
+    }
+
+    return null;
+  };
+
+  const activeContent = {
+    profiles: renderProfiles(profileSummaries),
+    loyalty: renderLoyalty(loyaltySummaries),
+    credit: renderCredit(creditSummaries),
+    giftCards: renderGiftCards(giftCardSummaries),
+  }[activeTab];
+
+  return (
+    <MotionWrapper type="page" className="p-6">
+      <div className="mx-auto flex max-w-7xl flex-col gap-6">
+        <header className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <div>
+            <h1 className="text-3xl font-bold text-[#24242E]">Customer Relationship Hub</h1>
+            <p className="mt-1 text-sm text-muted">
+              Understand guests, monitor loyalty health, and manage balances from a single view.
+            </p>
+          </div>
+
+          <div className="relative w-full md:w-80">
+            <Search size={18} className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-[#24242E]/50" />
+            <input
+              value={searchTerm}
+              onChange={(event) => setSearchTerm(event.target.value)}
+              className="w-full rounded-full border border-[#D6D6D6] bg-white py-2 pl-10 pr-4 text-sm text-[#24242E] shadow-sm transition focus:border-[#EE766D] focus:ring-2 focus:ring-[#EE766D]/40"
+              placeholder="Search by name, tag, or card code"
+              type="search"
+            />
+          </div>
+        </header>
+
+        <section className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
+          {metricCards.map((metric) => {
+            const value = {
+              customers: totals.totalCustomers,
+              loyalty: totals.totalLoyaltyPoints,
+              credit: totals.totalCredit,
+              giftcards: totals.totalGiftBalance,
+            }[metric.key as 'customers' | 'loyalty' | 'credit' | 'giftcards'];
+
+            const formattedValue =
+              metric.key === 'loyalty'
+                ? value.toLocaleString()
+                : metric.key === 'customers'
+                ? value.toLocaleString()
+                : currencyFormatter.format(value);
+
+            return (
+              <Card
+                key={metric.key}
+                className="paper-card flex flex-col gap-2 border border-[#D6D6D6]/80 bg-white p-5 shadow-sm"
+                style={{ borderTopColor: metric.accent, borderTopWidth: '4px' }}
+              >
+                <span className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-[#24242E]/70">
+                  <span
+                    className="flex h-7 w-7 items-center justify-center rounded-full text-white"
+                    style={{ backgroundColor: metric.accent }}
+                  >
+                    {metric.icon}
+                  </span>
+                  {metric.label}
+                </span>
+                <span className="text-2xl font-semibold text-[#24242E]">{formattedValue}</span>
+                {metric.key === 'customers' && (
+                  <span className="text-xs text-muted">{totals.visitsLast30} visits in the past 30 days</span>
+                )}
+              </Card>
+            );
+          })}
+        </section>
+
+        <nav className="flex flex-wrap gap-2">
+          <TabButton
+            label="Profiles"
+            icon={<UserRound size={16} />}
+            isActive={activeTab === 'profiles'}
+            onClick={() => setActiveTab('profiles')}
+          />
+          <TabButton
+            label="Loyalty"
+            icon={<Sparkles size={16} />}
+            isActive={activeTab === 'loyalty'}
+            onClick={() => setActiveTab('loyalty')}
+          />
+          <TabButton
+            label="Store Credit"
+            icon={<Wallet2 size={16} />}
+            isActive={activeTab === 'credit'}
+            onClick={() => setActiveTab('credit')}
+          />
+          <TabButton
+            label="Gift Cards"
+            icon={<Gift size={16} />}
+            isActive={activeTab === 'giftCards'}
+            onClick={() => setActiveTab('giftCards')}
+          />
+        </nav>
+
+        <section>{activeContent}</section>
+      </div>
+
+      <AnimatePresence>
+        {drawer && (
+          <>
+            <motion.div
+              className="fixed inset-0 z-40 bg-black/40"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              onClick={closeDrawer}
+            />
+            <motion.aside
+              className="fixed inset-y-0 right-0 z-50 w-full max-w-md overflow-y-auto border-l border-[#D6D6D6] bg-surface-100 p-6 shadow-lg"
+              initial={{ x: '100%' }}
+              animate={{ x: 0 }}
+              exit={{ x: '100%' }}
+              transition={{ type: 'spring', stiffness: 260, damping: 28 }}
+            >
+              <div className="mb-6 flex items-center justify-between">
+                <div>
+                  <h2 className="text-xl font-semibold text-[#24242E]">
+                    {drawer.type === 'profiles' && 'Profile details'}
+                    {drawer.type === 'loyalty' && 'Loyalty ledger'}
+                    {drawer.type === 'credit' && 'Store credit ledger'}
+                    {drawer.type === 'gift' && 'Gift card ledger'}
+                  </h2>
+                  <p className="text-sm text-muted">{selectedCustomer?.name}</p>
+                </div>
+                <button
+                  type="button"
+                  onClick={closeDrawer}
+                  className="rounded-full border border-[#D6D6D6] p-2 text-[#24242E] transition hover:bg-[#EE766D] hover:text-white"
+                  aria-label="Close details"
+                >
+                  <X size={18} />
+                </button>
+              </div>
+              {renderDrawerContent()}
+            </motion.aside>
+          </>
+        )}
+      </AnimatePresence>
+    </MotionWrapper>
+  );
+};
+
+export default CustomersDashboard;

--- a/src/data/mockCustomers.ts
+++ b/src/data/mockCustomers.ts
@@ -1,0 +1,892 @@
+import { useMemo } from 'react';
+import { Customer, CustomerVisit, GiftCard } from '../types';
+
+export const mockCustomers: Customer[] = [
+  {
+    id: 'cust-1',
+    name: 'John Smith',
+    phone: '555-0101',
+    email: 'john.smith@email.com',
+    birthday: '1985-06-18',
+    tags: ['VIP', 'Wine Club'],
+    notes: 'Prefers window seating and is allergic to peanuts.',
+    loyaltyPoints: 1250,
+    storeCreditBalance: 15.5,
+    visits: [
+      {
+        date: '2024-03-12T19:45:00Z',
+        storeId: 'store-1',
+        orderId: 'ord-5124',
+        channel: 'dine-in',
+        totalSpend: 142.35,
+        pointsEarned: 250,
+      },
+      {
+        date: '2024-02-18T20:10:00Z',
+        storeId: 'store-1',
+        orderId: 'ord-4932',
+        channel: 'dine-in',
+        totalSpend: 118.2,
+        pointsEarned: 220,
+        pointsRedeemed: 120,
+      },
+      {
+        date: '2024-01-14T17:15:00Z',
+        storeId: 'store-1',
+        orderId: 'ord-4610',
+        channel: 'takeaway',
+        totalSpend: 96.5,
+        pointsEarned: 180,
+      },
+      {
+        date: '2023-12-22T18:40:00Z',
+        storeId: 'store-1',
+        orderId: 'ord-4419',
+        channel: 'dine-in',
+        totalSpend: 153.9,
+        pointsEarned: 280,
+      },
+    ],
+    loyalty: {
+      tier: 'Gold',
+      lifetimePoints: 14250,
+      pointsToNextReward: 250,
+      lastEarnedOn: '2024-03-12T19:45:00Z',
+      lastRedeemedOn: '2024-02-05T18:00:00Z',
+      expiring: [
+        { points: 120, expiresOn: '2024-09-30T23:59:59Z' },
+        { points: 80, expiresOn: '2024-12-31T23:59:59Z' },
+      ],
+      history: [
+        {
+          id: 'loy-1001',
+          type: 'earn',
+          points: 280,
+          balanceAfter: 1080,
+          date: '2023-12-22T18:40:00Z',
+          reference: 'ord-4419',
+          note: 'Dinner for 4 - Table 6',
+        },
+        {
+          id: 'loy-1002',
+          type: 'earn',
+          points: 180,
+          balanceAfter: 1260,
+          date: '2024-01-14T17:15:00Z',
+          reference: 'ord-4610',
+        },
+        {
+          id: 'loy-1003',
+          type: 'redeem',
+          points: -120,
+          balanceAfter: 1140,
+          date: '2024-02-05T18:00:00Z',
+          reference: 'reward-455',
+          note: 'Redeemed for $12 dessert comp',
+        },
+        {
+          id: 'loy-1004',
+          type: 'earn',
+          points: 220,
+          balanceAfter: 1360,
+          date: '2024-02-18T20:10:00Z',
+          reference: 'ord-4932',
+        },
+        {
+          id: 'loy-1005',
+          type: 'earn',
+          points: 250,
+          balanceAfter: 1610,
+          date: '2024-03-12T19:45:00Z',
+          reference: 'ord-5124',
+        },
+        {
+          id: 'loy-1006',
+          type: 'adjust',
+          points: -360,
+          balanceAfter: 1250,
+          date: '2024-03-15T15:30:00Z',
+          reference: 'audit-2024-03',
+          note: 'Manual adjustment after double posting fix',
+        },
+      ],
+    },
+    storeCredits: [
+      {
+        id: 'credit-1001',
+        balance: 15.5,
+        issuedOn: '2023-12-18T00:00:00Z',
+        expiresOn: '2024-12-31T23:59:59Z',
+        lastUsedOn: '2024-03-12T19:45:00Z',
+        ledger: [
+          {
+            id: 'cred-ledger-1001',
+            type: 'issue',
+            amount: 25,
+            balanceAfter: 25,
+            date: '2023-12-18T00:00:00Z',
+            reference: 'promo-holiday',
+            note: 'Holiday goodwill credit',
+          },
+          {
+            id: 'cred-ledger-1002',
+            type: 'redeem',
+            amount: -9.5,
+            balanceAfter: 15.5,
+            date: '2024-03-12T19:45:00Z',
+            reference: 'ord-5124',
+            note: 'Applied to dinner check',
+          },
+        ],
+      },
+    ],
+    giftCards: [
+      {
+        code: 'GC-1001',
+        originalValue: 75,
+        balance: 35,
+        status: 'active',
+        issuedOn: '2023-11-20T00:00:00Z',
+        expiresOn: '2025-11-20T23:59:59Z',
+        lastUsedOn: '2024-01-14T17:15:00Z',
+        purchaseStoreId: 'store-1',
+        recipientName: 'John Smith',
+        transactions: [
+          {
+            id: 'gift-txn-1001',
+            type: 'issue',
+            amount: 75,
+            balanceAfter: 75,
+            date: '2023-11-20T00:00:00Z',
+            reference: 'gc-sale-884',
+          },
+          {
+            id: 'gift-txn-1002',
+            type: 'redeem',
+            amount: -40,
+            balanceAfter: 35,
+            date: '2024-01-14T17:15:00Z',
+            reference: 'ord-4610',
+            note: 'Applied to takeaway order',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'cust-2',
+    name: 'Emily Davis',
+    phone: '555-0102',
+    email: 'emily.davis@email.com',
+    birthday: '1990-09-03',
+    tags: ['Vegan', 'Newsletter'],
+    notes: 'Enjoys seasonal tasting menu and plant-based options.',
+    loyaltyPoints: 760,
+    storeCreditBalance: 30,
+    visits: [
+      {
+        date: '2024-03-08T18:20:00Z',
+        storeId: 'store-1',
+        orderId: 'ord-5088',
+        channel: 'dine-in',
+        totalSpend: 82.75,
+        pointsEarned: 160,
+      },
+      {
+        date: '2024-02-02T19:05:00Z',
+        storeId: 'store-1',
+        orderId: 'ord-4870',
+        channel: 'dine-in',
+        totalSpend: 95.4,
+        pointsEarned: 190,
+        pointsRedeemed: 80,
+      },
+      {
+        date: '2024-01-05T12:40:00Z',
+        storeId: 'store-1',
+        orderId: 'ord-4552',
+        channel: 'takeaway',
+        totalSpend: 54.1,
+        pointsEarned: 110,
+      },
+      {
+        date: '2023-11-17T20:05:00Z',
+        storeId: 'store-1',
+        orderId: 'ord-4304',
+        channel: 'dine-in',
+        totalSpend: 101.2,
+        pointsEarned: 205,
+      },
+    ],
+    loyalty: {
+      tier: 'Silver',
+      lifetimePoints: 6870,
+      pointsToNextReward: 240,
+      lastEarnedOn: '2024-03-08T18:20:00Z',
+      lastRedeemedOn: '2024-02-02T19:05:00Z',
+      expiring: [
+        { points: 60, expiresOn: '2024-06-30T23:59:59Z' },
+      ],
+      history: [
+        {
+          id: 'loy-2001',
+          type: 'earn',
+          points: 205,
+          balanceAfter: 640,
+          date: '2023-11-17T20:05:00Z',
+          reference: 'ord-4304',
+        },
+        {
+          id: 'loy-2002',
+          type: 'earn',
+          points: 110,
+          balanceAfter: 750,
+          date: '2024-01-05T12:40:00Z',
+          reference: 'ord-4552',
+        },
+        {
+          id: 'loy-2003',
+          type: 'redeem',
+          points: -80,
+          balanceAfter: 670,
+          date: '2024-02-02T19:05:00Z',
+          reference: 'reward-512',
+          note: 'Redeemed for free appetizer',
+        },
+        {
+          id: 'loy-2004',
+          type: 'earn',
+          points: 190,
+          balanceAfter: 860,
+          date: '2024-02-02T19:05:00Z',
+          reference: 'ord-4870',
+        },
+        {
+          id: 'loy-2005',
+          type: 'earn',
+          points: 160,
+          balanceAfter: 1020,
+          date: '2024-03-08T18:20:00Z',
+          reference: 'ord-5088',
+        },
+        {
+          id: 'loy-2006',
+          type: 'adjust',
+          points: -260,
+          balanceAfter: 760,
+          date: '2024-03-09T10:00:00Z',
+          reference: 'audit-2024-02',
+          note: 'Expired points auto-deducted',
+        },
+      ],
+    },
+    storeCredits: [
+      {
+        id: 'credit-2001',
+        balance: 20,
+        issuedOn: '2024-02-14T00:00:00Z',
+        expiresOn: '2024-05-31T23:59:59Z',
+        lastUsedOn: '2024-02-18T20:10:00Z',
+        ledger: [
+          {
+            id: 'cred-ledger-2001',
+            type: 'issue',
+            amount: 20,
+            balanceAfter: 20,
+            date: '2024-02-14T00:00:00Z',
+            reference: 'service-recovery-77',
+            note: 'Delayed order make-good',
+          },
+        ],
+      },
+      {
+        id: 'credit-2002',
+        balance: 10,
+        issuedOn: '2023-10-05T00:00:00Z',
+        expiresOn: '2024-03-31T23:59:59Z',
+        ledger: [
+          {
+            id: 'cred-ledger-2002',
+            type: 'issue',
+            amount: 10,
+            balanceAfter: 10,
+            date: '2023-10-05T00:00:00Z',
+            reference: 'promo-fall-harvest',
+          },
+        ],
+      },
+    ],
+    giftCards: [
+      {
+        code: 'GC-2045',
+        originalValue: 50,
+        balance: 12.5,
+        status: 'active',
+        issuedOn: '2023-12-01T00:00:00Z',
+        expiresOn: '2024-12-01T23:59:59Z',
+        lastUsedOn: '2024-02-02T19:05:00Z',
+        purchaseStoreId: 'store-1',
+        recipientName: 'Emily Davis',
+        transactions: [
+          {
+            id: 'gift-txn-2045-1',
+            type: 'issue',
+            amount: 50,
+            balanceAfter: 50,
+            date: '2023-12-01T00:00:00Z',
+            reference: 'gc-sale-992',
+          },
+          {
+            id: 'gift-txn-2045-2',
+            type: 'redeem',
+            amount: -37.5,
+            balanceAfter: 12.5,
+            date: '2024-02-02T19:05:00Z',
+            reference: 'ord-4870',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'cust-3',
+    name: 'Michael Johnson',
+    phone: '555-0103',
+    email: 'michael.johnson@email.com',
+    birthday: '1978-02-11',
+    tags: ['Corporate', 'Sommelier'],
+    notes: 'Hosts quarterly executive dinners; appreciates curated wine pairings.',
+    loyaltyPoints: 2100,
+    storeCreditBalance: 45,
+    visits: [
+      {
+        date: '2024-03-15T21:10:00Z',
+        storeId: 'store-1',
+        orderId: 'ord-5155',
+        channel: 'dine-in',
+        totalSpend: 248.4,
+        pointsEarned: 420,
+      },
+      {
+        date: '2024-02-20T20:30:00Z',
+        storeId: 'store-1',
+        orderId: 'ord-4951',
+        channel: 'dine-in',
+        totalSpend: 302.9,
+        pointsEarned: 520,
+        pointsRedeemed: 200,
+      },
+      {
+        date: '2024-01-22T19:50:00Z',
+        storeId: 'store-1',
+        orderId: 'ord-4705',
+        channel: 'dine-in',
+        totalSpend: 275.6,
+        pointsEarned: 480,
+      },
+      {
+        date: '2023-12-10T18:35:00Z',
+        storeId: 'store-1',
+        orderId: 'ord-4389',
+        channel: 'dine-in',
+        totalSpend: 198.5,
+        pointsEarned: 350,
+      },
+    ],
+    loyalty: {
+      tier: 'Platinum',
+      lifetimePoints: 18420,
+      pointsToNextReward: 100,
+      lastEarnedOn: '2024-03-15T21:10:00Z',
+      lastRedeemedOn: '2024-02-20T20:30:00Z',
+      expiring: [
+        { points: 240, expiresOn: '2024-08-31T23:59:59Z' },
+        { points: 180, expiresOn: '2025-01-31T23:59:59Z' },
+      ],
+      history: [
+        {
+          id: 'loy-3001',
+          type: 'earn',
+          points: 350,
+          balanceAfter: 1680,
+          date: '2023-12-10T18:35:00Z',
+          reference: 'ord-4389',
+        },
+        {
+          id: 'loy-3002',
+          type: 'earn',
+          points: 480,
+          balanceAfter: 2160,
+          date: '2024-01-22T19:50:00Z',
+          reference: 'ord-4705',
+        },
+        {
+          id: 'loy-3003',
+          type: 'redeem',
+          points: -200,
+          balanceAfter: 1960,
+          date: '2024-02-20T20:30:00Z',
+          reference: 'reward-640',
+          note: 'Redeemed for $20 off wine pairing',
+        },
+        {
+          id: 'loy-3004',
+          type: 'earn',
+          points: 520,
+          balanceAfter: 2480,
+          date: '2024-02-20T20:30:00Z',
+          reference: 'ord-4951',
+        },
+        {
+          id: 'loy-3005',
+          type: 'earn',
+          points: 420,
+          balanceAfter: 2900,
+          date: '2024-03-15T21:10:00Z',
+          reference: 'ord-5155',
+        },
+        {
+          id: 'loy-3006',
+          type: 'adjust',
+          points: -800,
+          balanceAfter: 2100,
+          date: '2024-03-18T14:20:00Z',
+          reference: 'audit-2024-03',
+          note: 'Converted expiring promo points',
+        },
+      ],
+    },
+    storeCredits: [
+      {
+        id: 'credit-3001',
+        balance: 25,
+        issuedOn: '2024-01-01T00:00:00Z',
+        expiresOn: '2024-09-30T23:59:59Z',
+        lastUsedOn: '2024-02-20T20:30:00Z',
+        ledger: [
+          {
+            id: 'cred-ledger-3001',
+            type: 'issue',
+            amount: 25,
+            balanceAfter: 25,
+            date: '2024-01-01T00:00:00Z',
+            reference: 'vip-bonus-q1',
+          },
+        ],
+      },
+      {
+        id: 'credit-3002',
+        balance: 20,
+        issuedOn: '2023-09-10T00:00:00Z',
+        expiresOn: '2024-04-15T23:59:59Z',
+        ledger: [
+          {
+            id: 'cred-ledger-3002',
+            type: 'issue',
+            amount: 20,
+            balanceAfter: 20,
+            date: '2023-09-10T00:00:00Z',
+            reference: 'corporate-invoice-adj',
+            note: 'Round down invoice credit',
+          },
+        ],
+      },
+    ],
+    giftCards: [
+      {
+        code: 'GC-3050',
+        originalValue: 100,
+        balance: 0,
+        status: 'redeemed',
+        issuedOn: '2023-06-15T00:00:00Z',
+        expiresOn: '2024-06-15T23:59:59Z',
+        lastUsedOn: '2024-01-22T19:50:00Z',
+        purchaseStoreId: 'store-1',
+        recipientName: 'Michael Johnson',
+        transactions: [
+          {
+            id: 'gift-txn-3050-1',
+            type: 'issue',
+            amount: 100,
+            balanceAfter: 100,
+            date: '2023-06-15T00:00:00Z',
+            reference: 'gc-sale-720',
+          },
+          {
+            id: 'gift-txn-3050-2',
+            type: 'redeem',
+            amount: -100,
+            balanceAfter: 0,
+            date: '2024-01-22T19:50:00Z',
+            reference: 'ord-4705',
+            note: 'Redeemed in full',
+          },
+        ],
+      },
+      {
+        code: 'GC-3051',
+        originalValue: 150,
+        balance: 150,
+        status: 'active',
+        issuedOn: '2024-03-01T00:00:00Z',
+        expiresOn: '2025-03-01T23:59:59Z',
+        purchaseStoreId: 'store-1',
+        recipientName: 'Michael Johnson',
+        transactions: [
+          {
+            id: 'gift-txn-3051-1',
+            type: 'issue',
+            amount: 150,
+            balanceAfter: 150,
+            date: '2024-03-01T00:00:00Z',
+            reference: 'gc-sale-1044',
+            note: 'Corporate thank you gift',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'cust-4',
+    name: 'Sofia Patel',
+    phone: '555-0104',
+    email: 'sofia.patel@email.com',
+    birthday: '1994-12-27',
+    tags: ['Takeaway Regular'],
+    notes: 'Prefers text notifications; gluten-free dietary preference.',
+    loyaltyPoints: 320,
+    storeCreditBalance: 0,
+    visits: [
+      {
+        date: '2024-03-10T12:05:00Z',
+        storeId: 'store-1',
+        orderId: 'ord-5061',
+        channel: 'delivery',
+        totalSpend: 48.2,
+        pointsEarned: 90,
+      },
+      {
+        date: '2024-02-16T13:20:00Z',
+        storeId: 'store-1',
+        orderId: 'ord-4912',
+        channel: 'takeaway',
+        totalSpend: 36.75,
+        pointsEarned: 70,
+      },
+      {
+        date: '2024-01-28T18:10:00Z',
+        storeId: 'store-1',
+        orderId: 'ord-4766',
+        channel: 'delivery',
+        totalSpend: 42.3,
+        pointsEarned: 80,
+      },
+      {
+        date: '2023-12-05T19:25:00Z',
+        storeId: 'store-1',
+        orderId: 'ord-4361',
+        channel: 'takeaway',
+        totalSpend: 39.95,
+        pointsEarned: 80,
+      },
+    ],
+    loyalty: {
+      tier: 'Bronze',
+      lifetimePoints: 2480,
+      pointsToNextReward: 180,
+      lastEarnedOn: '2024-03-10T12:05:00Z',
+      lastRedeemedOn: '2023-11-02T17:00:00Z',
+      expiring: [
+        { points: 45, expiresOn: '2024-05-15T23:59:59Z' },
+      ],
+      history: [
+        {
+          id: 'loy-4001',
+          type: 'earn',
+          points: 80,
+          balanceAfter: 260,
+          date: '2023-12-05T19:25:00Z',
+          reference: 'ord-4361',
+        },
+        {
+          id: 'loy-4002',
+          type: 'earn',
+          points: 80,
+          balanceAfter: 340,
+          date: '2024-01-28T18:10:00Z',
+          reference: 'ord-4766',
+        },
+        {
+          id: 'loy-4003',
+          type: 'earn',
+          points: 70,
+          balanceAfter: 410,
+          date: '2024-02-16T13:20:00Z',
+          reference: 'ord-4912',
+        },
+        {
+          id: 'loy-4004',
+          type: 'earn',
+          points: 90,
+          balanceAfter: 500,
+          date: '2024-03-10T12:05:00Z',
+          reference: 'ord-5061',
+        },
+        {
+          id: 'loy-4005',
+          type: 'adjust',
+          points: -180,
+          balanceAfter: 320,
+          date: '2024-03-11T08:30:00Z',
+          reference: 'auto-expiry',
+          note: 'Expired November points',
+        },
+      ],
+    },
+    storeCredits: [],
+    giftCards: [],
+  },
+];
+
+const normalizeSearch = (value: string) => value.trim().toLowerCase();
+
+export interface CustomerProfileSummary {
+  id: string;
+  name: string;
+  email?: string;
+  phone?: string;
+  tags: string[];
+  loyaltyTier: string;
+  loyaltyPoints: number;
+  storeCreditBalance: number;
+  totalVisits: number;
+  lastVisit?: string;
+  averageSpend: number;
+  lifetimeSpend: number;
+  birthday?: string;
+  notes?: string;
+}
+
+export const useCustomerProfiles = (searchTerm = ''): CustomerProfileSummary[] => {
+  return useMemo(() => {
+    const query = normalizeSearch(searchTerm);
+
+    return mockCustomers
+      .filter((customer) => {
+        if (!query) return true;
+
+        const haystack = [
+          customer.name,
+          customer.email ?? '',
+          customer.phone ?? '',
+          customer.tags?.join(' ') ?? '',
+          customer.notes ?? '',
+        ]
+          .join(' ')
+          .toLowerCase();
+
+        return haystack.includes(query);
+      })
+      .map<CustomerProfileSummary>((customer) => {
+        const sortedVisits = [...customer.visits].sort(
+          (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime(),
+        );
+        const lifetimeSpend = customer.visits.reduce((sum, visit) => sum + visit.totalSpend, 0);
+        const totalVisits = customer.visits.length;
+
+        return {
+          id: customer.id,
+          name: customer.name,
+          email: customer.email,
+          phone: customer.phone,
+          tags: customer.tags ?? [],
+          loyaltyTier: customer.loyalty.tier,
+          loyaltyPoints: customer.loyaltyPoints,
+          storeCreditBalance: customer.storeCreditBalance,
+          totalVisits,
+          lastVisit: sortedVisits[0]?.date,
+          averageSpend: totalVisits ? lifetimeSpend / totalVisits : 0,
+          lifetimeSpend,
+          birthday: customer.birthday,
+          notes: customer.notes,
+        };
+      })
+      .sort((a, b) => a.name.localeCompare(b.name));
+  }, [searchTerm]);
+};
+
+export interface CustomerLoyaltySummary {
+  customerId: string;
+  name: string;
+  tier: string;
+  points: number;
+  lifetimePoints: number;
+  pointsToNextReward: number;
+  lastEarnedOn?: string;
+  lastRedeemedOn?: string;
+  expiringPoints?: number;
+  nextExpiration?: string;
+}
+
+export const useLoyaltyAccounts = (searchTerm = ''): CustomerLoyaltySummary[] => {
+  return useMemo(() => {
+    const query = normalizeSearch(searchTerm);
+
+    return mockCustomers
+      .filter((customer) => {
+        if (!query) return true;
+        const haystack = [customer.name, customer.loyalty.tier]
+          .concat(customer.tags ?? [])
+          .join(' ')
+          .toLowerCase();
+        return haystack.includes(query);
+      })
+      .map<CustomerLoyaltySummary>((customer) => {
+        const upcoming = customer.loyalty.expiring
+          ?.slice()
+          .sort((a, b) => new Date(a.expiresOn).getTime() - new Date(b.expiresOn).getTime())[0];
+
+        return {
+          customerId: customer.id,
+          name: customer.name,
+          tier: customer.loyalty.tier,
+          points: customer.loyaltyPoints,
+          lifetimePoints: customer.loyalty.lifetimePoints,
+          pointsToNextReward: customer.loyalty.pointsToNextReward,
+          lastEarnedOn: customer.loyalty.lastEarnedOn,
+          lastRedeemedOn: customer.loyalty.lastRedeemedOn,
+          expiringPoints: upcoming?.points,
+          nextExpiration: upcoming?.expiresOn,
+        };
+      })
+      .sort((a, b) => b.points - a.points);
+  }, [searchTerm]);
+};
+
+export interface CustomerStoreCreditSummary {
+  customerId: string;
+  name: string;
+  totalBalance: number;
+  accountCount: number;
+  nextExpirationAmount?: number;
+  nextExpirationDate?: string;
+  lastUsedOn?: string;
+}
+
+export const useStoreCreditAccounts = (searchTerm = ''): CustomerStoreCreditSummary[] => {
+  return useMemo(() => {
+    const query = normalizeSearch(searchTerm);
+
+    return mockCustomers
+      .filter((customer) => {
+        if (!query) return true;
+        const haystack = [customer.name, customer.email ?? '', customer.phone ?? '']
+          .concat(customer.tags ?? [])
+          .join(' ')
+          .toLowerCase();
+        return haystack.includes(query);
+      })
+      .map<CustomerStoreCreditSummary>((customer) => {
+        const totalBalance = customer.storeCredits.reduce((sum, credit) => sum + credit.balance, 0);
+        const upcoming = customer.storeCredits
+          .filter((credit) => Boolean(credit.expiresOn))
+          .sort((a, b) =>
+            new Date(a.expiresOn ?? 0).getTime() - new Date(b.expiresOn ?? 0).getTime(),
+          )[0];
+        const lastUsedOn = customer.storeCredits
+          .map((credit) => credit.lastUsedOn)
+          .filter(Boolean)
+          .sort((a, b) => new Date(b ?? 0).getTime() - new Date(a ?? 0).getTime())[0];
+
+        return {
+          customerId: customer.id,
+          name: customer.name,
+          totalBalance,
+          accountCount: customer.storeCredits.length,
+          nextExpirationAmount: upcoming?.balance,
+          nextExpirationDate: upcoming?.expiresOn,
+          lastUsedOn,
+        };
+      })
+      .filter((summary) => summary.accountCount > 0)
+      .sort((a, b) => b.totalBalance - a.totalBalance);
+  }, [searchTerm]);
+};
+
+export interface GiftCardSummary {
+  code: string;
+  customerId: string;
+  customerName: string;
+  balance: number;
+  originalValue: number;
+  status: GiftCard['status'];
+  issuedOn: string;
+  expiresOn?: string;
+  lastUsedOn?: string;
+}
+
+export const useGiftCardSummaries = (searchTerm = ''): GiftCardSummary[] => {
+  return useMemo(() => {
+    const query = normalizeSearch(searchTerm);
+
+    const cards = mockCustomers.flatMap((customer) =>
+      customer.giftCards.map<GiftCardSummary>((card) => ({
+        code: card.code,
+        customerId: customer.id,
+        customerName: customer.name,
+        balance: card.balance,
+        originalValue: card.originalValue,
+        status: card.status,
+        issuedOn: card.issuedOn,
+        expiresOn: card.expiresOn,
+        lastUsedOn: card.lastUsedOn,
+      })),
+    );
+
+    return cards
+      .filter((card) => {
+        if (!query) return true;
+        const haystack = [card.code, card.customerName]
+          .join(' ')
+          .toLowerCase();
+        return haystack.includes(query);
+      })
+      .sort((a, b) => a.code.localeCompare(b.code));
+  }, [searchTerm]);
+};
+
+export const useCustomerById = (customerId?: string | null): Customer | undefined => {
+  return useMemo(() => {
+    if (!customerId) return undefined;
+    return mockCustomers.find((customer) => customer.id === customerId);
+  }, [customerId]);
+};
+
+export const useVisitHistory = (customerId?: string | null): CustomerVisit[] => {
+  const customer = useCustomerById(customerId);
+
+  return useMemo(() => {
+    if (!customer) return [];
+    return [...customer.visits].sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+  }, [customer]);
+};
+
+export const useGiftCardDetails = (
+  code?: string | null,
+): { customer: Customer; card: GiftCard } | undefined => {
+  return useMemo(() => {
+    if (!code) return undefined;
+
+    for (const customer of mockCustomers) {
+      const card = customer.giftCards.find((gift) => gift.code === code);
+      if (card) {
+        return { customer, card };
+      }
+    }
+
+    return undefined;
+  }, [code]);
+};
+
+export const getCustomerById = (customerId: string): Customer | undefined =>
+  mockCustomers.find((customer) => customer.id === customerId);

--- a/src/data/mockData.ts
+++ b/src/data/mockData.ts
@@ -1,4 +1,4 @@
-import { Product, Category, Customer, User, Store, Tenant } from '../types';
+import { Product, Category, User, Store, Tenant } from '../types';
 
 export const mockTenant: Tenant = {
   id: 'tenant-1',
@@ -255,28 +255,4 @@ export const mockProducts: Product[] = [
   }
 ];
 
-export const mockCustomers: Customer[] = [
-  {
-    id: 'cust-1',
-    name: 'John Smith',
-    phone: '555-0101',
-    email: 'john.smith@email.com',
-    loyaltyPoints: 1250,
-    storeCreditBalance: 15.50
-  },
-  {
-    id: 'cust-2',
-    name: 'Emily Davis',
-    phone: '555-0102',
-    email: 'emily.davis@email.com',
-    loyaltyPoints: 750,
-    storeCreditBalance: 0
-  },
-  {
-    id: 'cust-3',
-    name: 'Michael Johnson',
-    phone: '555-0103',
-    loyaltyPoints: 2100,
-    storeCreditBalance: 25.00
-  }
-];
+export { mockCustomers } from './mockCustomers';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -83,13 +83,99 @@ export interface Modifier {
   price: number;
 }
 
+export interface CustomerVisit {
+  date: string;
+  storeId: string;
+  orderId: string;
+  channel: 'dine-in' | 'takeaway' | 'delivery';
+  totalSpend: number;
+  pointsEarned: number;
+  pointsRedeemed?: number;
+}
+
+export interface LoyaltyExpiration {
+  points: number;
+  expiresOn: string;
+}
+
+export interface LoyaltyActivity {
+  id: string;
+  type: 'earn' | 'redeem' | 'adjust';
+  points: number;
+  balanceAfter: number;
+  date: string;
+  reference?: string;
+  note?: string;
+}
+
+export interface LoyaltyAccount {
+  tier: 'Bronze' | 'Silver' | 'Gold' | 'Platinum';
+  lifetimePoints: number;
+  pointsToNextReward: number;
+  lastEarnedOn?: string;
+  lastRedeemedOn?: string;
+  expiring?: LoyaltyExpiration[];
+  history: LoyaltyActivity[];
+}
+
+export interface StoreCreditLedgerEntry {
+  id: string;
+  type: 'issue' | 'redeem' | 'expire' | 'adjust';
+  amount: number;
+  balanceAfter: number;
+  date: string;
+  reference?: string;
+  note?: string;
+}
+
+export interface StoreCreditAccount {
+  id: string;
+  balance: number;
+  issuedOn: string;
+  expiresOn?: string;
+  lastUsedOn?: string;
+  ledger: StoreCreditLedgerEntry[];
+}
+
+export type GiftCardStatus = 'active' | 'redeemed' | 'void';
+
+export interface GiftCardTransaction {
+  id: string;
+  type: 'issue' | 'redeem' | 'refund' | 'adjust';
+  amount: number;
+  balanceAfter: number;
+  date: string;
+  reference?: string;
+  note?: string;
+}
+
+export interface GiftCard {
+  code: string;
+  originalValue: number;
+  balance: number;
+  status: GiftCardStatus;
+  issuedOn: string;
+  expiresOn?: string;
+  lastUsedOn?: string;
+  purchaseStoreId: string;
+  recipientName?: string;
+  transactions: GiftCardTransaction[];
+}
+
 export interface Customer {
   id: string;
   name: string;
   phone?: string;
   email?: string;
+  birthday?: string;
+  tags?: string[];
+  notes?: string;
   loyaltyPoints: number;
   storeCreditBalance: number;
+  visits: CustomerVisit[];
+  loyalty: LoyaltyAccount;
+  storeCredits: StoreCreditAccount[];
+  giftCards: GiftCard[];
 }
 
 export interface Order {


### PR DESCRIPTION
## Summary
- Implemented the Customers Relationship Hub with summary metrics, tabbed profile/loyalty/credit/gift-card views, and contextual drawers.
- Seeded detailed mock customer data with loyalty, visit, credit, and gift card histories plus selector hooks.
- Wired the POS cart sidebar to a new customer picker modal powered by the shared dataset and updated routing to expose the dashboard.

## Testing
- npm run lint *(fails: pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cffb37d2208326b9b85842421ad65c