### PR TITLE
feat: add inventory dashboard experience

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -118,10 +118,22 @@
 ---
 
 ## Agent 10 — Database/Functionality Checks
-**Scope:** Ensure functional logic and DB integration still work after UI changes.  
-**Tasks:**  
-- Verify forms still submit correctly.  
-- Confirm API/data fetching unaffected.  
-- Log any issues needing backend fixes.  
-**Status:** TODO  
-**Log:**  
+**Scope:** Ensure functional logic and DB integration still work after UI changes.
+**Tasks:**
+- Verify forms still submit correctly.
+- Confirm API/data fetching unaffected.
+- Log any issues needing backend fixes.
+**Status:** TODO
+**Log:**
+
+---
+
+## Agent 13 — Inventory Dashboard
+**Scope:** Build inventory dashboards, FEFO surfacing, and stock health indicators.
+**Tasks:**
+- Design the inventory command center with KPIs, alerts, and tabbed views.
+- Implement shared status pills for stock levels and expiry windows.
+- Wire mock inventory data into a lightweight store feeding the dashboard.
+**Status:** DONE
+**Log:**
+- Created FEFO-aware mock inventory data, Zustand store selectors, reusable status pills, and the Inventory dashboard route with KPIs, alerts, and tabbed views; `npm run lint` still fails due to pre-existing violations outside this scope.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,13 +6,13 @@ import { Login } from './components/auth/Login';
 import { Portal } from './components/apps/Portal';
 import { POS } from './components/apps/POS';
 import { BackOffice } from './components/apps/BackOffice';
+import { InventoryDashboard } from './components/apps/inventory/InventoryDashboard';
 import { useAuthStore } from './stores/authStore';
 import { useOfflineStore } from './stores/offlineStore';
 
 // Placeholder components for other apps
 const KDS = () => <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="p-6"><h2 className="text-2xl font-bold">Kitchen Display System</h2><p className="text-muted mt-2">Coming soon...</p></motion.div>;
 const Products = () => <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="p-6"><h2 className="text-2xl font-bold">Product Catalog</h2><p className="text-muted mt-2">Coming soon...</p></motion.div>;
-const Inventory = () => <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="p-6"><h2 className="text-2xl font-bold">Inventory Management</h2><p className="text-muted mt-2">Coming soon...</p></motion.div>;
 const Customers = () => <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="p-6"><h2 className="text-2xl font-bold">Customer Management</h2><p className="text-muted mt-2">Coming soon...</p></motion.div>;
 const Promotions = () => <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="p-6"><h2 className="text-2xl font-bold">Promotions</h2><p className="text-muted mt-2">Coming soon...</p></motion.div>;
 const Reports = () => <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="p-6"><h2 className="text-2xl font-bold">Reports & Analytics</h2><p className="text-muted mt-2">Coming soon...</p></motion.div>;
@@ -59,7 +59,7 @@ function App() {
           <Route path="pos" element={<POS />} />
           <Route path="kds" element={<KDS />} />
           <Route path="products" element={<Products />} />
-          <Route path="inventory" element={<Inventory />} />
+          <Route path="inventory" element={<InventoryDashboard />} />
           <Route path="customers" element={<Customers />} />
           <Route path="promotions" element={<Promotions />} />
           <Route path="reports" element={<Reports />} />

--- a/src/components/apps/inventory/InventoryDashboard.tsx
+++ b/src/components/apps/inventory/InventoryDashboard.tsx
@@ -1,0 +1,502 @@
+import React, { useMemo, useState } from 'react';
+import { format, parseISO } from 'date-fns';
+import { Card } from '@mas/ui';
+
+import { MotionWrapper } from '../../ui/MotionWrapper';
+import { ExpiryStatusPill, StatusPill, StockStatusPill } from '../../ui/status';
+import { useInventoryStore } from '../../../stores/inventoryStore';
+import { useAuthStore } from '../../../stores/authStore';
+import { InventoryAlert, InventoryBatchWithMeta, InventoryCountStatus, InventoryMovementType } from '../../../types';
+
+type InventoryTab = 'on-hand' | 'movements' | 'counts' | 'batches';
+
+const tabOrder: Array<{ id: InventoryTab; label: string; description: string }> = [
+  { id: 'on-hand', label: 'On hand', description: 'Snapshot of current availability' },
+  { id: 'movements', label: 'Movements', description: 'Receipts, transfers, and waste' },
+  { id: 'counts', label: 'Counts', description: 'Cycle counts and audits' },
+  { id: 'batches', label: 'Batches', description: 'FEFO lots and expiry windows' }
+];
+
+const movementTone: Record<InventoryMovementType, 'info' | 'success' | 'warning' | 'danger' | 'neutral'> = {
+  receipt: 'success',
+  transfer: 'info',
+  adjustment: 'warning',
+  sale: 'neutral',
+  waste: 'danger'
+};
+
+const countTone: Record<InventoryCountStatus, 'info' | 'success' | 'warning'> = {
+  scheduled: 'info',
+  'in-progress': 'warning',
+  completed: 'success'
+};
+
+const locale = 'en-US';
+
+const formatQuantity = (value: number, fractionDigits = 0) =>
+  new Intl.NumberFormat(locale, { maximumFractionDigits: fractionDigits }).format(value);
+
+const formatDate = (value: string, pattern = 'MMM d, yyyy') => {
+  try {
+    return format(parseISO(value), pattern);
+  } catch {
+    return value;
+  }
+};
+
+const buildAlertKey = (alert: InventoryAlert) =>
+  `${alert.type}-${alert.sku}-${alert.lotCode ?? 'na'}`;
+
+export const InventoryDashboard: React.FC = () => {
+  const [activeTab, setActiveTab] = useState<InventoryTab>('on-hand');
+
+  const items = useInventoryStore(state => state.items);
+  const batches = useInventoryStore(state => state.batches);
+  const movements = useInventoryStore(state => state.movements);
+  const counts = useInventoryStore(state => state.counts);
+  const getKpis = useInventoryStore(state => state.getKpis);
+  const getAlerts = useInventoryStore(state => state.getAlerts);
+  const getFefoQueue = useInventoryStore(state => state.getFefoQueue);
+  const tenant = useAuthStore(state => state.tenant);
+
+  const currencyCode = tenant?.settings.currency ?? 'USD';
+
+  const currencyFormatter = useMemo(
+    () =>
+      new Intl.NumberFormat(locale, {
+        style: 'currency',
+        currency: currencyCode,
+        maximumFractionDigits: 0
+      }),
+    [currencyCode]
+  );
+
+  const kpis = getKpis();
+  const alerts = getAlerts();
+  const fefoQueue = getFefoQueue();
+
+  const itemBySku = useMemo(() => new Map(items.map(item => [item.sku, item])), [items]);
+  const batchMetaByLot = useMemo(() => {
+    const map = new Map<string, InventoryBatchWithMeta>();
+    fefoQueue.forEach(batch => map.set(batch.lotCode, batch));
+    return map;
+  }, [fefoQueue]);
+
+  const totalOnHand = items.reduce((sum, item) => sum + item.onHand, 0);
+  const totalAvailable = items.reduce((sum, item) => sum + item.available, 0);
+
+  const topFefo = fefoQueue.slice(0, 5);
+
+  const renderAlerts = () => (
+    <div className="space-y-4">
+      {alerts.length === 0 ? (
+        <div className="rounded-lg border border-line bg-surface-200/60 p-6 text-sm text-muted">
+          All clear—no low stock or expiry risk in the next window.
+        </div>
+      ) : (
+        alerts.map(alert => {
+          const item = itemBySku.get(alert.sku);
+          const batchMeta = alert.lotCode ? batchMetaByLot.get(alert.lotCode) : undefined;
+
+          return (
+            <div
+              key={buildAlertKey(alert)}
+              className="flex flex-col gap-3 rounded-xl border border-line bg-surface-100/90 p-4 shadow-sm transition hover:border-primary-200 hover:shadow-md md:flex-row md:items-center md:justify-between"
+            >
+              <div className="space-y-1">
+                <p className="text-sm font-semibold text-ink">
+                  {alert.type === 'reorder'
+                    ? item?.name ?? alert.name
+                    : `${item?.name ?? alert.sku}`}
+                </p>
+                <p className="text-xs text-muted">
+                  {alert.type === 'reorder'
+                    ? `${item?.sku ?? alert.sku} • ${item?.supplier ?? 'Supplier TBD'}`
+                    : `Lot ${alert.lotCode} • ${alert.sku}`}
+                </p>
+                <p className="text-sm text-muted">{alert.message}</p>
+              </div>
+
+              <div className="flex flex-col items-start gap-2 md:items-end">
+                {alert.type === 'reorder' ? (
+                  <StockStatusPill
+                    available={alert.available ?? 0}
+                    reorderPoint={alert.reorderPoint ?? item?.reorderPoint ?? 0}
+                    parLevel={item?.parLevel ?? alert.reorderPoint ?? 1}
+                    avgDailyUsage={item?.avgDailyUsage}
+                  />
+                ) : (
+                  <ExpiryStatusPill
+                    daysUntilExpiry={batchMeta?.daysUntilExpiry ?? alert.daysUntilExpiry ?? 0}
+                    fefoOrder={batchMeta?.fefoOrder}
+                  />
+                )}
+
+                {alert.type === 'reorder' ? (
+                  <span className="text-xs text-muted font-tabular">
+                    Available: {formatQuantity(alert.available ?? 0)} {item?.uom ?? ''} • Reorder at{' '}
+                    {formatQuantity(alert.reorderPoint ?? item?.reorderPoint ?? 0)}
+                  </span>
+                ) : (
+                  <span className="text-xs text-muted font-tabular">
+                    Remaining: {formatQuantity(batchMeta?.remaining ?? 0)} {item?.uom ?? ''}
+                  </span>
+                )}
+              </div>
+            </div>
+          );
+        })
+      )}
+    </div>
+  );
+
+  const renderOnHand = () => (
+    <div className="overflow-x-auto">
+      <table className="min-w-full text-sm">
+        <thead className="border-b border-line/70 text-left text-xs uppercase tracking-wide text-muted">
+          <tr>
+            <th scope="col" className="py-3 pr-6 font-medium">
+              Item
+            </th>
+            <th scope="col" className="py-3 pr-6 font-medium">
+              On hand
+            </th>
+            <th scope="col" className="py-3 pr-6 font-medium">
+              Allocated
+            </th>
+            <th scope="col" className="py-3 pr-6 font-medium">
+              Available
+            </th>
+            <th scope="col" className="py-3 pr-6 font-medium">
+              Coverage
+            </th>
+            <th scope="col" className="py-3 pr-6 font-medium">
+              Value
+            </th>
+            <th scope="col" className="py-3 font-medium">
+              Status
+            </th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-line/70">
+          {items.map(item => {
+            const coverage = item.avgDailyUsage
+              ? Math.max(item.available / item.avgDailyUsage, 0)
+              : undefined;
+            const formattedCoverage = coverage
+              ? `${formatQuantity(coverage, coverage >= 5 ? 0 : 1)} d`
+              : '—';
+
+            return (
+              <tr
+                key={item.sku}
+                className="transition-colors hover:bg-surface-200/60"
+              >
+                <td className="py-4 pr-6">
+                  <div className="flex flex-col gap-1">
+                    <span className="font-medium text-ink">{item.name}</span>
+                    <span className="text-xs text-muted">
+                      {item.sku} • {item.category} • {item.uom}
+                    </span>
+                  </div>
+                </td>
+                <td className="py-4 pr-6 font-tabular">{formatQuantity(item.onHand)}</td>
+                <td className="py-4 pr-6 font-tabular text-warning">
+                  {formatQuantity(item.allocated)}
+                </td>
+                <td className="py-4 pr-6 font-tabular">{formatQuantity(item.available)}</td>
+                <td className="py-4 pr-6 font-tabular text-muted">{formattedCoverage}</td>
+                <td className="py-4 pr-6 font-tabular">
+                  {currencyFormatter.format(item.onHand * item.cost)}
+                </td>
+                <td className="py-4">
+                  <StockStatusPill
+                    available={item.available}
+                    reorderPoint={item.reorderPoint}
+                    parLevel={item.parLevel}
+                    avgDailyUsage={item.avgDailyUsage}
+                  />
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+
+  const renderMovements = () => (
+    <div className="space-y-3">
+      {movements.map(movement => {
+        const typeTone = movementTone[movement.type];
+        const item = itemBySku.get(movement.sku);
+
+        const quantityClass = movement.quantity < 0 ? 'text-danger' : 'text-success';
+
+        return (
+          <div
+            key={movement.id}
+            className="flex flex-col gap-3 rounded-lg border border-line bg-surface-100/90 p-4 md:flex-row md:items-center md:justify-between"
+          >
+            <div className="space-y-1">
+              <p className="text-sm font-semibold text-ink">{movement.reference}</p>
+              <p className="text-xs text-muted">
+                {item?.name ?? movement.sku} • {movement.sku}
+              </p>
+              <p className="text-xs text-muted">{formatDate(movement.createdAt, 'MMM d, yyyy • HH:mm')}</p>
+            </div>
+
+            <div className="flex flex-col items-start gap-2 md:items-end">
+              <div className="flex flex-wrap items-center gap-2">
+                <StatusPill tone={typeTone === 'neutral' ? 'neutral' : typeTone}>
+                  {movement.type.replace('-', ' ')}
+                </StatusPill>
+                <span className={`font-semibold font-tabular ${quantityClass}`}>
+                  {movement.quantity > 0 ? '+' : ''}
+                  {formatQuantity(movement.quantity)} {movement.uom}
+                </span>
+              </div>
+              <div className="text-xs text-muted">
+                {movement.source ? `From ${movement.source}` : ''}
+                {movement.destination ? ` → ${movement.destination}` : ''}
+                {movement.note ? ` • ${movement.note}` : ''}
+              </div>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+
+  const renderCounts = () => (
+    <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+      {counts.map(count => (
+        <Card key={count.id} className="space-y-3">
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <p className="text-sm font-semibold text-ink">{count.name}</p>
+              <p className="text-xs text-muted">{formatDate(count.scheduledFor, 'MMM d, yyyy • HH:mm')}</p>
+            </div>
+            <StatusPill tone={countTone[count.status]}>{count.status.replace('-', ' ')}</StatusPill>
+          </div>
+          <div className="text-xs text-muted">
+            Assigned to <span className="font-medium text-ink">{count.assignee}</span>
+          </div>
+          {typeof count.variance === 'number' && (
+            <div className="text-xs font-medium font-tabular">
+              Variance: <span className={count.variance >= 0 ? 'text-success' : 'text-danger'}>{count.variance > 0 ? '+' : ''}{count.variance}</span>
+            </div>
+          )}
+        </Card>
+      ))}
+    </div>
+  );
+
+  const renderBatches = () => (
+    <div className="overflow-x-auto">
+      <table className="min-w-full text-sm">
+        <thead className="border-b border-line/70 text-left text-xs uppercase tracking-wide text-muted">
+          <tr>
+            <th scope="col" className="py-3 pr-6 font-medium">
+              Lot
+            </th>
+            <th scope="col" className="py-3 pr-6 font-medium">
+              SKU
+            </th>
+            <th scope="col" className="py-3 pr-6 font-medium">
+              Supplier
+            </th>
+            <th scope="col" className="py-3 pr-6 font-medium">
+              Remaining
+            </th>
+            <th scope="col" className="py-3 pr-6 font-medium">
+              Received
+            </th>
+            <th scope="col" className="py-3 font-medium">
+              Expiry
+            </th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-line/70">
+          {fefoQueue.map(batch => {
+            const item = itemBySku.get(batch.sku);
+
+            return (
+              <tr key={batch.id} className="transition-colors hover:bg-surface-200/60">
+                <td className="py-4 pr-6">
+                  <div className="flex flex-col gap-1">
+                    <span className="font-medium text-ink">{batch.lotCode}</span>
+                    <span className="text-xs text-muted">
+                      FEFO order #{batch.fefoOrder}
+                    </span>
+                  </div>
+                </td>
+                <td className="py-4 pr-6 text-xs text-muted">{batch.sku}</td>
+                <td className="py-4 pr-6 text-xs text-muted">{batch.supplier}</td>
+                <td className="py-4 pr-6 font-tabular">
+                  {formatQuantity(batch.remaining)} {item?.uom ?? ''}
+                </td>
+                <td className="py-4 pr-6 text-xs text-muted">{formatDate(batch.receivedAt)}</td>
+                <td className="py-4">
+                  <ExpiryStatusPill
+                    daysUntilExpiry={batch.daysUntilExpiry}
+                    fefoOrder={batch.fefoOrder}
+                  />
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+
+  return (
+    <MotionWrapper type="page" className="p-6">
+      <div className="mx-auto flex w-full max-w-7xl flex-col gap-8">
+        <div className="flex flex-col gap-3">
+          <div className="flex flex-wrap items-center justify-between gap-4">
+            <div>
+              <h1 className="text-3xl font-bold text-ink">Inventory command center</h1>
+              <p className="text-muted">
+                Track FEFO lots, watch reorder points, and keep every station stocked for service.
+              </p>
+            </div>
+            <div className="rounded-lg border border-line bg-surface-200/60 px-4 py-2 text-right">
+              <p className="text-xs text-muted uppercase tracking-wide">Stock coverage</p>
+              <p className="text-sm font-semibold text-ink font-tabular">
+                {formatQuantity(totalAvailable)} available / {formatQuantity(totalOnHand)} on hand
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
+          <Card className="space-y-2">
+            <p className="text-xs uppercase tracking-wide text-muted">Total SKUs</p>
+            <p className="text-3xl font-semibold text-ink font-tabular">{kpis.totalSkus}</p>
+            <p className="text-xs text-muted">Across {items.length} tracked items</p>
+          </Card>
+          <Card className="space-y-2">
+            <p className="text-xs uppercase tracking-wide text-muted">On-hand value</p>
+            <p className="text-3xl font-semibold text-ink font-tabular">
+              {currencyFormatter.format(kpis.onHandValue)}
+            </p>
+            <p className="text-xs text-muted">Gross at cost for current stock</p>
+          </Card>
+          <Card className="space-y-2">
+            <p className="text-xs uppercase tracking-wide text-muted">Low stock</p>
+            <p className="text-3xl font-semibold text-warning font-tabular">{kpis.lowStock}</p>
+            <p className="text-xs text-muted">Below reorder threshold</p>
+          </Card>
+          <Card className="space-y-2">
+            <p className="text-xs uppercase tracking-wide text-muted">Near expiry</p>
+            <p className="text-3xl font-semibold text-danger font-tabular">{kpis.nearExpiry}</p>
+            <p className="text-xs text-muted">Lots within the critical window</p>
+          </Card>
+        </div>
+
+        <div className="grid grid-cols-1 gap-6 xl:grid-cols-3">
+          <Card className="space-y-4 xl:col-span-2">
+            <div className="flex items-center justify-between gap-4">
+              <div>
+                <h2 className="text-xl font-semibold text-ink">Live alerts</h2>
+                <p className="text-sm text-muted">Reorder and expiry risk surfaced in real time.</p>
+              </div>
+              <StatusPill tone="warning">{alerts.length} open</StatusPill>
+            </div>
+            {renderAlerts()}
+          </Card>
+
+          <Card className="space-y-4">
+            <div>
+              <h2 className="text-xl font-semibold text-ink">FEFO queue</h2>
+              <p className="text-sm text-muted">Next lots to pull across all prep stations.</p>
+            </div>
+            <div className="space-y-3">
+              {topFefo.map(batch => {
+                const item = itemBySku.get(batch.sku);
+
+                return (
+                  <div key={batch.id} className="rounded-lg border border-line/60 bg-surface-200/40 p-3">
+                    <div className="flex items-center justify-between gap-3">
+                      <div>
+                        <p className="text-sm font-semibold text-ink">{item?.name ?? batch.sku}</p>
+                        <p className="text-xs text-muted">Lot {batch.lotCode} • {batch.sku}</p>
+                      </div>
+                      <ExpiryStatusPill
+                        daysUntilExpiry={batch.daysUntilExpiry}
+                        fefoOrder={batch.fefoOrder}
+                      />
+                    </div>
+                    <div className="mt-2 flex flex-wrap items-center gap-3 text-xs text-muted font-tabular">
+                      <span>Remaining {formatQuantity(batch.remaining)} {item?.uom ?? ''}</span>
+                      <span>Received {formatDate(batch.receivedAt)}</span>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </Card>
+        </div>
+
+        <Card className="space-y-6">
+          <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+            <div>
+              <h2 className="text-xl font-semibold text-ink">Inventory detail views</h2>
+              <p className="text-sm text-muted">Switch between stock positions, recent movements, counts, and batch tracking.</p>
+            </div>
+            <div role="tablist" aria-label="Inventory detail views" className="flex flex-wrap gap-2">
+              {tabOrder.map(tab => {
+                const isActive = tab.id === activeTab;
+                return (
+                  <button
+                    key={tab.id}
+                    type="button"
+                    role="tab"
+                    id={`${tab.id}-tab`}
+                    aria-controls={`${tab.id}-panel`}
+                    aria-selected={isActive}
+                    onClick={() => setActiveTab(tab.id)}
+                    className={`rounded-full border px-4 py-2 text-sm font-medium transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 ${
+                      isActive
+                        ? 'border-primary-500 bg-primary-500 text-white shadow'
+                        : 'border-line bg-surface-200/70 text-muted hover:border-primary-200 hover:text-ink'
+                    }`}
+                  >
+                    <span>{tab.label}</span>
+                    <span className="ml-2 rounded-full bg-surface-100 px-2 py-0.5 text-xs font-semibold text-muted">
+                      {tab.id === 'on-hand'
+                        ? items.length
+                        : tab.id === 'movements'
+                        ? movements.length
+                        : tab.id === 'counts'
+                        ? counts.length
+                        : batches.length}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          {tabOrder.map(tab => (
+            <div
+              key={tab.id}
+              id={`${tab.id}-panel`}
+              role="tabpanel"
+              aria-labelledby={`${tab.id}-tab`}
+              hidden={activeTab !== tab.id}
+              className="space-y-4"
+            >
+              {tab.id === 'on-hand' && renderOnHand()}
+              {tab.id === 'movements' && renderMovements()}
+              {tab.id === 'counts' && renderCounts()}
+              {tab.id === 'batches' && renderBatches()}
+            </div>
+          ))}
+        </Card>
+      </div>
+    </MotionWrapper>
+  );
+};

--- a/src/components/ui/status/ExpiryStatusPill.tsx
+++ b/src/components/ui/status/ExpiryStatusPill.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { AlertTriangle, CheckCircle, Clock } from 'lucide-react';
+import { StatusPill, StatusPillProps, StatusTone } from './StatusPill';
+
+interface ExpiryStatusPillProps extends Omit<StatusPillProps, 'tone' | 'icon'> {
+  daysUntilExpiry: number;
+  fefoOrder?: number;
+}
+
+const pluralise = (value: number) => `${Math.abs(value)} day${Math.abs(value) === 1 ? '' : 's'}`;
+
+export const ExpiryStatusPill: React.FC<ExpiryStatusPillProps> = ({
+  daysUntilExpiry,
+  fefoOrder,
+  className = '',
+  ...props
+}) => {
+  let tone: StatusTone = 'info';
+  let label: string;
+  let icon = <CheckCircle size={14} />;
+
+  if (daysUntilExpiry < 0) {
+    tone = 'danger';
+    icon = <AlertTriangle size={14} />;
+    label = `Expired ${pluralise(daysUntilExpiry)} ago`;
+  } else if (daysUntilExpiry === 0) {
+    tone = 'danger';
+    icon = <AlertTriangle size={14} />;
+    label = 'Expires today';
+  } else if (daysUntilExpiry <= 3) {
+    tone = 'danger';
+    icon = <AlertTriangle size={14} />;
+    label = `Expires in ${pluralise(daysUntilExpiry)}`;
+  } else if (daysUntilExpiry <= 7) {
+    tone = 'warning';
+    icon = <Clock size={14} />;
+    label = `${pluralise(daysUntilExpiry)} remaining`;
+  } else if (daysUntilExpiry <= 21) {
+    tone = 'info';
+    icon = <Clock size={14} />;
+    label = `${pluralise(daysUntilExpiry)} remaining`;
+  } else {
+    tone = 'success';
+    icon = <CheckCircle size={14} />;
+    label = 'Fresh stock';
+  }
+
+  const fefoText = fefoOrder ? `FEFO #${fefoOrder}` : '';
+  const text = fefoText ? `${fefoText} · ${label}` : label;
+
+  return (
+    <StatusPill tone={tone} icon={icon} className={className} {...props}>
+      {text}
+    </StatusPill>
+  );
+};

--- a/src/components/ui/status/StatusPill.tsx
+++ b/src/components/ui/status/StatusPill.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+
+export type StatusTone = 'neutral' | 'info' | 'success' | 'warning' | 'danger';
+
+const toneStyles: Record<StatusTone, string> = {
+  neutral:
+    'border-line/70 bg-surface-200/70 text-ink-70 dark:text-ink flex-shrink-0',
+  info: 'border-primary-200 bg-primary-100 text-primary-600 flex-shrink-0',
+  success: 'border-success/20 bg-success/10 text-success flex-shrink-0',
+  warning: 'border-warning/30 bg-warning/10 text-warning flex-shrink-0',
+  danger: 'border-danger/20 bg-danger/10 text-danger flex-shrink-0'
+};
+
+export interface StatusPillProps extends React.HTMLAttributes<HTMLSpanElement> {
+  tone?: StatusTone;
+  icon?: React.ReactNode;
+  subtle?: boolean;
+}
+
+export const StatusPill: React.FC<StatusPillProps> = ({
+  tone = 'neutral',
+  icon,
+  children,
+  className = '',
+  subtle = false,
+  ...props
+}) => {
+  const baseTone = toneStyles[tone];
+  const transparency = subtle ? 'bg-transparent border-transparent' : '';
+
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium ${baseTone} ${transparency} ${className}`}
+      {...props}
+    >
+      {icon ? <span className="flex items-center" aria-hidden>{icon}</span> : null}
+      <span className="whitespace-nowrap">{children}</span>
+    </span>
+  );
+};

--- a/src/components/ui/status/StockStatusPill.tsx
+++ b/src/components/ui/status/StockStatusPill.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { AlertTriangle, CheckCircle, TrendingDown, Warehouse } from 'lucide-react';
+import { StatusPill, StatusPillProps, StatusTone } from './StatusPill';
+
+interface StockStatusPillProps extends Omit<StatusPillProps, 'tone' | 'icon'> {
+  available: number;
+  reorderPoint: number;
+  parLevel: number;
+  avgDailyUsage?: number;
+}
+
+const formatCoverage = (available: number, avgDailyUsage?: number) => {
+  if (!avgDailyUsage || avgDailyUsage <= 0) {
+    return '';
+  }
+
+  const coverage = Math.max(available / avgDailyUsage, 0);
+  if (!Number.isFinite(coverage)) {
+    return '';
+  }
+
+  const rounded = coverage >= 5 ? Math.round(coverage) : Math.round(coverage * 10) / 10;
+  return `${rounded}d cover`;
+};
+
+export const StockStatusPill: React.FC<StockStatusPillProps> = ({
+  available,
+  reorderPoint,
+  parLevel,
+  avgDailyUsage,
+  className = '',
+  ...props
+}) => {
+  let tone: StatusTone = 'success';
+  let label = 'Stock healthy';
+  let icon: React.ReactNode = <CheckCircle size={14} />;
+
+  if (available <= 0) {
+    tone = 'danger';
+    label = 'Out of stock';
+    icon = <AlertTriangle size={14} />;
+  } else if (available <= reorderPoint) {
+    tone = 'warning';
+    label = 'Reorder now';
+    icon = <AlertTriangle size={14} />;
+  } else if (available < parLevel * 0.6) {
+    tone = 'info';
+    label = 'Below par';
+    icon = <TrendingDown size={14} />;
+  } else {
+    tone = 'success';
+    label = 'Stock healthy';
+    icon = <Warehouse size={14} />;
+  }
+
+  const coverage = formatCoverage(available, avgDailyUsage);
+  const text = coverage ? `${label} · ${coverage}` : label;
+
+  return (
+    <StatusPill tone={tone} icon={icon} className={className} {...props}>
+      {text}
+    </StatusPill>
+  );
+};

--- a/src/components/ui/status/index.ts
+++ b/src/components/ui/status/index.ts
@@ -1,0 +1,3 @@
+export * from './StatusPill';
+export * from './StockStatusPill';
+export * from './ExpiryStatusPill';

--- a/src/data/mockInventory.ts
+++ b/src/data/mockInventory.ts
@@ -1,0 +1,280 @@
+import {
+  InventoryBatch,
+  InventoryCount,
+  InventoryItem,
+  InventoryMovement
+} from '../types';
+
+export const mockInventoryItems: InventoryItem[] = [
+  {
+    sku: 'ING-ESP-001',
+    name: 'Espresso Beans — House Blend',
+    category: 'Beverages',
+    uom: 'kg',
+    supplier: 'Peak Roastery',
+    parLevel: 45,
+    reorderPoint: 18,
+    onHand: 36,
+    allocated: 6,
+    available: 30,
+    avgDailyUsage: 4.2,
+    cost: 12.5,
+    lastMovementAt: '2025-03-18T14:30:00Z',
+    lastCountAt: '2025-03-01T09:15:00Z',
+    fefoEnabled: true,
+    batches: ['batch-espresso-1', 'batch-espresso-2']
+  },
+  {
+    sku: 'DAIR-WHM-004',
+    name: 'Whole Milk 2L (6 pack)',
+    category: 'Dairy',
+    uom: 'case',
+    supplier: 'EverFresh Dairy Co.',
+    parLevel: 32,
+    reorderPoint: 14,
+    onHand: 18,
+    allocated: 5,
+    available: 13,
+    avgDailyUsage: 5,
+    cost: 22.5,
+    lastMovementAt: '2025-03-19T07:50:00Z',
+    lastCountAt: '2025-03-15T08:00:00Z',
+    fefoEnabled: true,
+    batches: ['batch-milk-1', 'batch-milk-2']
+  },
+  {
+    sku: 'BAR-CTR-009',
+    name: 'Citrus Syrup Concentrate',
+    category: 'Bar Prep',
+    uom: 'bottle',
+    supplier: 'SunState Provisions',
+    parLevel: 24,
+    reorderPoint: 8,
+    onHand: 11,
+    allocated: 1,
+    available: 10,
+    avgDailyUsage: 1.8,
+    cost: 6.2,
+    lastMovementAt: '2025-03-17T17:05:00Z',
+    lastCountAt: '2025-03-12T10:20:00Z',
+    fefoEnabled: false,
+    batches: ['batch-citrus-1']
+  },
+  {
+    sku: 'PRT-STK-002',
+    name: 'Striploin Steak (Sous-vide)',
+    category: 'Proteins',
+    uom: 'vac-pack',
+    supplier: 'Heritage Farms',
+    parLevel: 28,
+    reorderPoint: 12,
+    onHand: 14,
+    allocated: 4,
+    available: 10,
+    avgDailyUsage: 3.5,
+    cost: 18.4,
+    lastMovementAt: '2025-03-20T12:10:00Z',
+    lastCountAt: '2025-03-10T11:45:00Z',
+    fefoEnabled: true,
+    batches: ['batch-steak-1', 'batch-steak-2']
+  },
+  {
+    sku: 'PRO-MIX-007',
+    name: 'Mixed Greens (2lb clamshell)',
+    category: 'Produce',
+    uom: 'case',
+    supplier: 'Urban Harvest',
+    parLevel: 20,
+    reorderPoint: 10,
+    onHand: 9,
+    allocated: 3,
+    available: 6,
+    avgDailyUsage: 2.8,
+    cost: 9.75,
+    lastMovementAt: '2025-03-21T06:40:00Z',
+    lastCountAt: '2025-03-18T07:30:00Z',
+    fefoEnabled: true,
+    batches: ['batch-greens-1', 'batch-greens-2']
+  }
+];
+
+export const mockInventoryBatches: InventoryBatch[] = [
+  {
+    id: 'batch-espresso-1',
+    sku: 'ING-ESP-001',
+    lotCode: 'ESP-2501A',
+    supplier: 'Peak Roastery',
+    receivedAt: '2025-02-10T09:00:00Z',
+    expiryDate: '2025-08-15T00:00:00Z',
+    quantity: 20,
+    remaining: 14,
+    fefoOrder: 1
+  },
+  {
+    id: 'batch-espresso-2',
+    sku: 'ING-ESP-001',
+    lotCode: 'ESP-2502B',
+    supplier: 'Peak Roastery',
+    receivedAt: '2025-03-12T09:00:00Z',
+    expiryDate: '2025-10-12T00:00:00Z',
+    quantity: 18,
+    remaining: 16,
+    fefoOrder: 2
+  },
+  {
+    id: 'batch-milk-1',
+    sku: 'DAIR-WHM-004',
+    lotCode: 'WHM-2409C',
+    supplier: 'EverFresh Dairy Co.',
+    receivedAt: '2025-03-14T05:30:00Z',
+    expiryDate: '2025-03-30T00:00:00Z',
+    quantity: 12,
+    remaining: 4,
+    fefoOrder: 1
+  },
+  {
+    id: 'batch-milk-2',
+    sku: 'DAIR-WHM-004',
+    lotCode: 'WHM-2409D',
+    supplier: 'EverFresh Dairy Co.',
+    receivedAt: '2025-03-18T05:30:00Z',
+    expiryDate: '2025-04-04T00:00:00Z',
+    quantity: 12,
+    remaining: 9,
+    fefoOrder: 2
+  },
+  {
+    id: 'batch-citrus-1',
+    sku: 'BAR-CTR-009',
+    lotCode: 'CTR-2501',
+    supplier: 'SunState Provisions',
+    receivedAt: '2025-01-22T11:00:00Z',
+    expiryDate: '2025-05-30T00:00:00Z',
+    quantity: 24,
+    remaining: 10,
+    fefoOrder: 1
+  },
+  {
+    id: 'batch-steak-1',
+    sku: 'PRT-STK-002',
+    lotCode: 'STK-2501',
+    supplier: 'Heritage Farms',
+    receivedAt: '2025-03-02T08:00:00Z',
+    expiryDate: '2025-03-28T00:00:00Z',
+    quantity: 10,
+    remaining: 4,
+    fefoOrder: 1
+  },
+  {
+    id: 'batch-steak-2',
+    sku: 'PRT-STK-002',
+    lotCode: 'STK-2502',
+    supplier: 'Heritage Farms',
+    receivedAt: '2025-03-15T08:00:00Z',
+    expiryDate: '2025-04-20T00:00:00Z',
+    quantity: 8,
+    remaining: 6,
+    fefoOrder: 2
+  },
+  {
+    id: 'batch-greens-1',
+    sku: 'PRO-MIX-007',
+    lotCode: 'GRN-2508',
+    supplier: 'Urban Harvest',
+    receivedAt: '2025-03-10T06:15:00Z',
+    expiryDate: '2025-03-18T00:00:00Z',
+    quantity: 10,
+    remaining: 2,
+    fefoOrder: 1
+  },
+  {
+    id: 'batch-greens-2',
+    sku: 'PRO-MIX-007',
+    lotCode: 'GRN-2509',
+    supplier: 'Urban Harvest',
+    receivedAt: '2025-03-18T06:15:00Z',
+    expiryDate: '2025-03-25T00:00:00Z',
+    quantity: 8,
+    remaining: 4,
+    fefoOrder: 2
+  }
+];
+
+export const mockInventoryMovements: InventoryMovement[] = [
+  {
+    id: 'move-001',
+    sku: 'ING-ESP-001',
+    type: 'receipt',
+    reference: 'PO-4521',
+    quantity: 18,
+    uom: 'kg',
+    createdAt: '2025-03-15T10:30:00Z',
+    source: 'Peak Roastery'
+  },
+  {
+    id: 'move-002',
+    sku: 'DAIR-WHM-004',
+    type: 'transfer',
+    reference: 'TR-1098',
+    quantity: -4,
+    uom: 'case',
+    createdAt: '2025-03-18T12:45:00Z',
+    source: 'Main Cooler',
+    destination: 'Cafe Front'
+  },
+  {
+    id: 'move-003',
+    sku: 'PRT-STK-002',
+    type: 'waste',
+    reference: 'WS-334',
+    quantity: -2,
+    uom: 'vac-pack',
+    createdAt: '2025-03-19T19:10:00Z',
+    note: 'Expired lot STK-2501'
+  },
+  {
+    id: 'move-004',
+    sku: 'BAR-CTR-009',
+    type: 'adjustment',
+    reference: 'ADJ-775',
+    quantity: 1,
+    uom: 'bottle',
+    createdAt: '2025-03-16T08:20:00Z',
+    note: 'Line check variance correction'
+  },
+  {
+    id: 'move-005',
+    sku: 'PRO-MIX-007',
+    type: 'sale',
+    reference: 'POS-88321',
+    quantity: -6,
+    uom: 'case',
+    createdAt: '2025-03-20T21:15:00Z'
+  }
+];
+
+export const mockInventoryCounts: InventoryCount[] = [
+  {
+    id: 'count-001',
+    name: 'Weekly Line Check — Bar',
+    scheduledFor: '2025-03-22T07:00:00Z',
+    status: 'scheduled',
+    assignee: 'Jordan (Bar Lead)'
+  },
+  {
+    id: 'count-002',
+    name: 'Freezer Cycle Count',
+    scheduledFor: '2025-03-21T09:30:00Z',
+    status: 'in-progress',
+    assignee: 'Priya (Sous Chef)',
+    variance: -1
+  },
+  {
+    id: 'count-003',
+    name: 'Produce Spot Check',
+    scheduledFor: '2025-03-19T06:45:00Z',
+    status: 'completed',
+    assignee: 'Alex (Inventory)',
+    variance: 2
+  }
+];

--- a/src/stores/inventoryStore.ts
+++ b/src/stores/inventoryStore.ts
@@ -1,0 +1,136 @@
+import { create } from 'zustand';
+import { differenceInCalendarDays, parseISO } from 'date-fns';
+
+import {
+  InventoryAlert,
+  InventoryBatch,
+  InventoryBatchStatus,
+  InventoryBatchWithMeta,
+  InventoryCount,
+  InventoryItem,
+  InventoryKpis,
+  InventoryMovement
+} from '../types';
+import {
+  mockInventoryBatches,
+  mockInventoryCounts,
+  mockInventoryItems,
+  mockInventoryMovements
+} from '../data/mockInventory';
+
+interface InventoryState {
+  items: InventoryItem[];
+  batches: InventoryBatch[];
+  movements: InventoryMovement[];
+  counts: InventoryCount[];
+  getKpis: () => InventoryKpis;
+  getAlerts: () => InventoryAlert[];
+  getFefoQueue: (sku?: string) => InventoryBatchWithMeta[];
+}
+
+const computeBatchMeta = (batch: InventoryBatch): InventoryBatchWithMeta => {
+  const today = new Date();
+  const expiry = parseISO(batch.expiryDate);
+  const daysUntilExpiry = differenceInCalendarDays(expiry, today);
+
+  let status: InventoryBatchStatus;
+  if (daysUntilExpiry < 0 || daysUntilExpiry <= 2) {
+    status = 'critical';
+  } else if (daysUntilExpiry <= 7) {
+    status = 'warning';
+  } else {
+    status = 'healthy';
+  }
+
+  return {
+    ...batch,
+    daysUntilExpiry,
+    status
+  };
+};
+
+const computeKpis = (items: InventoryItem[], batches: InventoryBatch[]) => {
+  const totalSkus = items.length;
+  const onHandValue = items.reduce((sum, item) => sum + item.onHand * item.cost, 0);
+  const lowStock = items.filter(item => item.available <= item.reorderPoint).length;
+
+  const nearExpiry = batches
+    .map(computeBatchMeta)
+    .filter(batch => batch.status !== 'healthy').length;
+
+  const kpis: InventoryKpis = {
+    totalSkus,
+    onHandValue,
+    lowStock,
+    nearExpiry
+  };
+
+  return kpis;
+};
+
+const computeAlerts = (
+  items: InventoryItem[],
+  batches: InventoryBatch[]
+): InventoryAlert[] => {
+  const alerts: InventoryAlert[] = [];
+
+  items.forEach(item => {
+    if (item.available <= item.reorderPoint) {
+      alerts.push({
+        sku: item.sku,
+        name: item.name,
+        type: 'reorder',
+        severity: item.available <= 0 ? 'danger' : 'warning',
+        available: item.available,
+        reorderPoint: item.reorderPoint,
+        message:
+          item.available <= 0
+            ? 'Allocate emergency stock or adjust recipe until replenished.'
+            : 'Forecast will breach par within the next service. Plan a PO now.'
+      });
+    }
+  });
+
+  batches
+    .map(computeBatchMeta)
+    .filter(batch => batch.status !== 'healthy')
+    .forEach(batch => {
+      alerts.push({
+        sku: batch.sku,
+        name: batch.lotCode,
+        type: 'expiry',
+        severity: batch.status === 'critical' ? 'danger' : 'warning',
+        lotCode: batch.lotCode,
+        daysUntilExpiry: batch.daysUntilExpiry,
+        message:
+          batch.daysUntilExpiry < 0
+            ? 'Batch expired—quarantine stock and trigger a waste record.'
+            : 'Schedule FEFO pulls to burn through this lot before service.'
+      });
+    });
+
+  return alerts;
+};
+
+export const useInventoryStore = create<InventoryState>((_set, get) => ({
+  items: mockInventoryItems,
+  batches: mockInventoryBatches,
+  movements: mockInventoryMovements,
+  counts: mockInventoryCounts,
+  getKpis: () => {
+    const { items, batches } = get();
+    return computeKpis(items, batches);
+  },
+  getAlerts: () => {
+    const { items, batches } = get();
+    return computeAlerts(items, batches);
+  },
+  getFefoQueue: (sku?: string) => {
+    const { batches } = get();
+    const relevant = sku ? batches.filter(batch => batch.sku === sku) : batches;
+
+    return relevant
+      .map(computeBatchMeta)
+      .sort((a, b) => a.daysUntilExpiry - b.daysUntilExpiry || a.fefoOrder - b.fefoOrder);
+  }
+}));

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -189,3 +189,96 @@ export interface MotionPresets {
     duration: number;
   };
 }
+
+// Inventory domain
+export type InventoryMovementType =
+  | 'receipt'
+  | 'transfer'
+  | 'adjustment'
+  | 'sale'
+  | 'waste';
+
+export type InventoryBatchStatus = 'healthy' | 'warning' | 'critical';
+
+export type InventoryCountStatus = 'scheduled' | 'in-progress' | 'completed';
+
+export type InventoryAlertType = 'reorder' | 'expiry';
+
+export type InventoryAlertSeverity = 'warning' | 'danger';
+
+export interface InventoryItem {
+  sku: string;
+  name: string;
+  category: string;
+  uom: string;
+  supplier: string;
+  parLevel: number;
+  reorderPoint: number;
+  onHand: number;
+  allocated: number;
+  available: number;
+  avgDailyUsage: number;
+  cost: number;
+  lastMovementAt: string;
+  lastCountAt: string;
+  fefoEnabled: boolean;
+  batches: string[];
+}
+
+export interface InventoryBatch {
+  id: string;
+  sku: string;
+  lotCode: string;
+  supplier: string;
+  receivedAt: string;
+  expiryDate: string;
+  quantity: number;
+  remaining: number;
+  fefoOrder: number;
+}
+
+export interface InventoryBatchWithMeta extends InventoryBatch {
+  daysUntilExpiry: number;
+  status: InventoryBatchStatus;
+}
+
+export interface InventoryMovement {
+  id: string;
+  sku: string;
+  type: InventoryMovementType;
+  reference: string;
+  quantity: number;
+  uom: string;
+  createdAt: string;
+  source?: string;
+  destination?: string;
+  note?: string;
+}
+
+export interface InventoryCount {
+  id: string;
+  name: string;
+  scheduledFor: string;
+  status: InventoryCountStatus;
+  assignee: string;
+  variance?: number;
+}
+
+export interface InventoryAlert {
+  sku: string;
+  name: string;
+  type: InventoryAlertType;
+  severity: InventoryAlertSeverity;
+  message: string;
+  available?: number;
+  reorderPoint?: number;
+  lotCode?: string;
+  daysUntilExpiry?: number;
+}
+
+export interface InventoryKpis {
+  totalSkus: number;
+  onHandValue: number;
+  lowStock: number;
+  nearExpiry: number;
+}


### PR DESCRIPTION
## Summary
- build an inventory dashboard that surfaces KPIs, live alerts, FEFO queues, and tabbed detail views
- add shared status pill components for stock levels and expiry windows for reuse across the suite
- seed mock inventory data and expose it through a lightweight Zustand store

## Testing
- npm run lint *(fails: pre-existing lint violations outside the new inventory scope)*

------
https://chatgpt.com/codex/tasks/task_e_68cffb36ec308326b6b3b381c6d0fbc2