### PR TITLE
feat: add products dashboard and table primitives

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -118,10 +118,23 @@
 ---
 
 ## Agent 10 — Database/Functionality Checks
-**Scope:** Ensure functional logic and DB integration still work after UI changes.  
-**Tasks:**  
-- Verify forms still submit correctly.  
-- Confirm API/data fetching unaffected.  
-- Log any issues needing backend fixes.  
-**Status:** TODO  
-**Log:**  
+**Scope:** Ensure functional logic and DB integration still work after UI changes.
+**Tasks:**
+- Verify forms still submit correctly.
+- Confirm API/data fetching unaffected.
+- Log any issues needing backend fixes.
+**Status:** TODO
+**Log:**
+
+---
+
+## Agent 12 — Products Admin
+**Scope:** Products dashboard scaffolding and data plumbing.
+**Tasks:**
+- Build dashboard UI with tabs and paginated tables.
+- Introduce reusable table primitives for admin surfaces.
+- Load mock datasets and wire up state placeholders.
+- Confirm `/products` route renders the new surface.
+**Status:** DONE
+**Log:**
+- 2024-10-06: Implemented Products dashboard with tabbed, searchable tables backed by Zustand mock data, extracted reusable data-table primitives, and routed `/products` to the new view.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,12 +6,12 @@ import { Login } from './components/auth/Login';
 import { Portal } from './components/apps/Portal';
 import { POS } from './components/apps/POS';
 import { BackOffice } from './components/apps/BackOffice';
+import { ProductsDashboard } from './components/apps/products/ProductsDashboard';
 import { useAuthStore } from './stores/authStore';
 import { useOfflineStore } from './stores/offlineStore';
 
 // Placeholder components for other apps
 const KDS = () => <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="p-6"><h2 className="text-2xl font-bold">Kitchen Display System</h2><p className="text-muted mt-2">Coming soon...</p></motion.div>;
-const Products = () => <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="p-6"><h2 className="text-2xl font-bold">Product Catalog</h2><p className="text-muted mt-2">Coming soon...</p></motion.div>;
 const Inventory = () => <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="p-6"><h2 className="text-2xl font-bold">Inventory Management</h2><p className="text-muted mt-2">Coming soon...</p></motion.div>;
 const Customers = () => <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="p-6"><h2 className="text-2xl font-bold">Customer Management</h2><p className="text-muted mt-2">Coming soon...</p></motion.div>;
 const Promotions = () => <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="p-6"><h2 className="text-2xl font-bold">Promotions</h2><p className="text-muted mt-2">Coming soon...</p></motion.div>;
@@ -58,7 +58,7 @@ function App() {
           <Route path="portal" element={<Portal />} />
           <Route path="pos" element={<POS />} />
           <Route path="kds" element={<KDS />} />
-          <Route path="products" element={<Products />} />
+          <Route path="products" element={<ProductsDashboard />} />
           <Route path="inventory" element={<Inventory />} />
           <Route path="customers" element={<Customers />} />
           <Route path="promotions" element={<Promotions />} />

--- a/src/components/apps/products/ProductsDashboard.tsx
+++ b/src/components/apps/products/ProductsDashboard.tsx
@@ -1,0 +1,776 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  ListChecks,
+  Package,
+  RefreshCcw,
+  Search,
+  SlidersHorizontal
+} from 'lucide-react';
+import { Card, Button } from '@mas/ui';
+import { cn } from '@mas/utils';
+import { MotionWrapper } from '../../ui/MotionWrapper';
+import {
+  DataTable,
+  DataTableColumn,
+  DataTablePagination
+} from '../../ui/data-table';
+import { useProductsAdminStore } from '../../../stores/productsAdminStore';
+import {
+  ProductAdminItem,
+  ProductAdminModifierGroup,
+  ProductAdminPriceList,
+  ProductLifecycleStatus,
+  ModifierGroupStatus,
+  PriceListStatus
+} from '../../../data/mockProductsAdmin';
+
+const toneClasses: Record<
+  'primary' | 'success' | 'warning' | 'neutral' | 'danger',
+  string
+> = {
+  primary:
+    'border-primary-200 bg-primary-100 text-primary-600 dark:bg-primary-200/20',
+  success: 'border-success/20 bg-success/10 text-success',
+  warning: 'border-warning/20 bg-warning/10 text-warning',
+  neutral: 'border-line bg-surface-200 text-muted',
+  danger: 'border-danger/20 bg-danger/10 text-danger'
+};
+
+const renderStatusPill = (
+  label: string,
+  tone: 'primary' | 'success' | 'warning' | 'neutral' | 'danger'
+) => (
+  <span
+    className={cn(
+      'inline-flex items-center justify-center rounded-full px-2.5 py-1 text-[11px] font-semibold uppercase tracking-wide',
+      toneClasses[tone]
+    )}
+  >
+    {label}
+  </span>
+);
+
+const lifecyclePill = (status: ProductLifecycleStatus) => {
+  switch (status) {
+    case 'active':
+      return renderStatusPill('Active', 'success');
+    case 'draft':
+      return renderStatusPill('Draft', 'warning');
+    case 'archived':
+      return renderStatusPill('Archived', 'neutral');
+    default:
+      return renderStatusPill(status, 'neutral');
+  }
+};
+
+const modifierStatusPill = (status: ModifierGroupStatus) => {
+  switch (status) {
+    case 'active':
+      return renderStatusPill('Active', 'success');
+    case 'draft':
+      return renderStatusPill('Draft', 'warning');
+    case 'retired':
+      return renderStatusPill('Retired', 'neutral');
+    default:
+      return renderStatusPill(status, 'neutral');
+  }
+};
+
+const priceListStatusPill = (status: PriceListStatus) => {
+  switch (status) {
+    case 'live':
+      return renderStatusPill('Live', 'success');
+    case 'scheduled':
+      return renderStatusPill('Scheduled', 'primary');
+    case 'expired':
+      return renderStatusPill('Expired', 'danger');
+    default:
+      return renderStatusPill(status, 'neutral');
+  }
+};
+
+const formatCurrency = (value: number, currency = 'USD') => {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency,
+    maximumFractionDigits: 2
+  }).format(value);
+};
+
+const formatDate = (value: string) => {
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric'
+  }).format(new Date(value));
+};
+
+const formatDateTime = (value: string) => {
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit'
+  }).format(new Date(value));
+};
+
+const toTitleCase = (value: string) =>
+  value
+    .split('-')
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(' ');
+
+type TabKey = 'items' | 'modifiers' | 'priceLists';
+
+const tabs: Array<{ id: TabKey; label: string; description: string }> = [
+  {
+    id: 'items',
+    label: 'Items',
+    description: 'Catalog items, pricing and gross margin tracking'
+  },
+  {
+    id: 'modifiers',
+    label: 'Modifiers',
+    description: 'Modifier groups, required rules and menu attachments'
+  },
+  {
+    id: 'priceLists',
+    label: 'Price Lists',
+    description: 'Location-specific price schedules and sync status'
+  }
+];
+
+const searchPlaceholders: Record<TabKey, string> = {
+  items: 'Search items, SKUs, tags or locations…',
+  modifiers: 'Search modifier groups or attached items…',
+  priceLists: 'Search price lists, channels or locations…'
+};
+
+const pageSizeOptions: Record<TabKey, number[]> = {
+  items: [5, 8, 12],
+  modifiers: [5, 8, 12],
+  priceLists: [5, 8, 12]
+};
+
+export const ProductsDashboard: React.FC = () => {
+  const {
+    items,
+    modifiers,
+    priceLists,
+    isLoading,
+    lastSyncedAt,
+    initialize,
+    refresh
+  } = useProductsAdminStore();
+  const [activeTab, setActiveTab] = useState<TabKey>('items');
+  const [searchTerms, setSearchTerms] = useState<Record<TabKey, string>>({
+    items: '',
+    modifiers: '',
+    priceLists: ''
+  });
+  const [page, setPage] = useState<Record<TabKey, number>>({
+    items: 1,
+    modifiers: 1,
+    priceLists: 1
+  });
+  const [pageSize, setPageSize] = useState<Record<TabKey, number>>({
+    items: 8,
+    modifiers: 8,
+    priceLists: 8
+  });
+
+  useEffect(() => {
+    initialize();
+  }, [initialize]);
+
+  const filteredItems = useMemo(() => {
+    const term = searchTerms.items.trim().toLowerCase();
+    if (!term) {
+      return items;
+    }
+
+    return items.filter((item) => {
+      const haystack = [
+        item.name,
+        item.sku,
+        item.category,
+        item.location,
+        item.status,
+        item.salesChannel
+      ]
+        .join(' ')
+        .toLowerCase();
+
+      const tagMatch = item.tags.some((tag) => tag.toLowerCase().includes(term));
+      return haystack.includes(term) || tagMatch;
+    });
+  }, [items, searchTerms.items]);
+
+  const filteredModifiers = useMemo(() => {
+    const term = searchTerms.modifiers.trim().toLowerCase();
+    if (!term) {
+      return modifiers;
+    }
+
+    return modifiers.filter((group) => {
+      const haystack = [
+        group.name,
+        group.status,
+        group.required ? 'required' : 'optional',
+        ...group.appliesTo
+      ]
+        .join(' ')
+        .toLowerCase();
+      return haystack.includes(term);
+    });
+  }, [modifiers, searchTerms.modifiers]);
+
+  const filteredPriceLists = useMemo(() => {
+    const term = searchTerms.priceLists.trim().toLowerCase();
+    if (!term) {
+      return priceLists;
+    }
+
+    return priceLists.filter((list) => {
+      const haystack = [
+        list.name,
+        list.status,
+        list.currency,
+        ...list.channels,
+        ...list.locations
+      ]
+        .join(' ')
+        .toLowerCase();
+      return haystack.includes(term);
+    });
+  }, [priceLists, searchTerms.priceLists]);
+
+  const itemsTotalPages = Math.max(1, Math.ceil(filteredItems.length / pageSize.items));
+  const modifiersTotalPages = Math.max(
+    1,
+    Math.ceil(filteredModifiers.length / pageSize.modifiers)
+  );
+  const priceListsTotalPages = Math.max(
+    1,
+    Math.ceil(filteredPriceLists.length / pageSize.priceLists)
+  );
+
+  const currentItemsPage = Math.min(page.items, itemsTotalPages);
+  const currentModifiersPage = Math.min(page.modifiers, modifiersTotalPages);
+  const currentPriceListsPage = Math.min(page.priceLists, priceListsTotalPages);
+
+  const paginatedItems = useMemo(() => {
+    const startIndex = (currentItemsPage - 1) * pageSize.items;
+    return filteredItems.slice(startIndex, startIndex + pageSize.items);
+  }, [filteredItems, currentItemsPage, pageSize.items]);
+
+  const paginatedModifiers = useMemo(() => {
+    const startIndex = (currentModifiersPage - 1) * pageSize.modifiers;
+    return filteredModifiers.slice(startIndex, startIndex + pageSize.modifiers);
+  }, [filteredModifiers, currentModifiersPage, pageSize.modifiers]);
+
+  const paginatedPriceLists = useMemo(() => {
+    const startIndex = (currentPriceListsPage - 1) * pageSize.priceLists;
+    return filteredPriceLists.slice(startIndex, startIndex + pageSize.priceLists);
+  }, [filteredPriceLists, currentPriceListsPage, pageSize.priceLists]);
+
+  const tabCounts: Record<TabKey, number> = {
+    items: filteredItems.length,
+    modifiers: filteredModifiers.length,
+    priceLists: filteredPriceLists.length
+  };
+
+  const handleSearchChange = (tab: TabKey, value: string) => {
+    setSearchTerms((prev) => ({ ...prev, [tab]: value }));
+    setPage((prev) => ({ ...prev, [tab]: 1 }));
+  };
+
+  const handlePageChange = (tab: TabKey, nextPage: number) => {
+    setPage((prev) => ({ ...prev, [tab]: nextPage }));
+  };
+
+  const handlePageSizeChange = (tab: TabKey, size: number) => {
+    setPageSize((prev) => ({ ...prev, [tab]: size }));
+    setPage((prev) => ({ ...prev, [tab]: 1 }));
+  };
+
+  const activeItems = useMemo(
+    () => items.filter((item) => item.status === 'active').length,
+    [items]
+  );
+  const draftItems = useMemo(
+    () => items.filter((item) => item.status === 'draft').length,
+    [items]
+  );
+  const activeModifiers = useMemo(
+    () => modifiers.filter((group) => group.status === 'active').length,
+    [modifiers]
+  );
+  const requiredModifiers = useMemo(
+    () => modifiers.filter((group) => group.required).length,
+    [modifiers]
+  );
+  const livePriceLists = useMemo(
+    () => priceLists.filter((list) => list.status === 'live').length,
+    [priceLists]
+  );
+  const scheduledPriceLists = useMemo(
+    () => priceLists.filter((list) => list.status === 'scheduled').length,
+    [priceLists]
+  );
+
+  const summaryCards = [
+    {
+      id: 'catalog',
+      label: 'Catalog Items',
+      value: items.length,
+      meta: `${activeItems} active • ${draftItems} draft`,
+      icon: Package
+    },
+    {
+      id: 'modifiers',
+      label: 'Modifier Groups',
+      value: modifiers.length,
+      meta: `${requiredModifiers} required • ${activeModifiers} active`,
+      icon: SlidersHorizontal
+    },
+    {
+      id: 'prices',
+      label: 'Price Lists',
+      value: priceLists.length,
+      meta: `${livePriceLists} live • ${scheduledPriceLists} scheduled`,
+      icon: ListChecks
+    }
+  ];
+
+  const itemColumns = useMemo<DataTableColumn<ProductAdminItem>[]>(
+    () => [
+      {
+        key: 'item',
+        header: 'Item',
+        width: '28%',
+        cell: (item) => (
+          <div className="flex flex-col gap-1">
+            <span className="font-medium text-ink">{item.name}</span>
+            <span className="text-xs text-muted">
+              {item.sku} • {item.category}
+            </span>
+          </div>
+        )
+      },
+      {
+        key: 'tags',
+        header: 'Tags',
+        cell: (item) => (
+          <div className="flex flex-wrap gap-2">
+            {item.tags.slice(0, 3).map((tag) => (
+              <span
+                key={`${item.id}-${tag}`}
+                className="inline-flex items-center rounded-full bg-surface-200 px-2 py-0.5 text-xs font-medium text-muted"
+              >
+                {tag}
+              </span>
+            ))}
+            {item.tags.length > 3 && (
+              <span className="text-xs text-muted">+{item.tags.length - 3} more</span>
+            )}
+          </div>
+        )
+      },
+      {
+        key: 'channel',
+        header: 'Channel',
+        cell: (item) => (
+          <span className="text-sm font-medium text-ink">
+            {item.salesChannel === 'all'
+              ? 'All Channels'
+              : toTitleCase(item.salesChannel)}
+          </span>
+        )
+      },
+      {
+        key: 'price',
+        header: 'Price',
+        align: 'right',
+        width: 120,
+        cell: (item) => (
+          <span className="font-semibold text-ink">
+            {formatCurrency(item.price)}
+          </span>
+        )
+      },
+      {
+        key: 'margin',
+        header: 'Margin',
+        align: 'right',
+        width: 120,
+        cell: (item) => {
+          const grossMargin = Math.max(item.price - item.cost, 0);
+          const marginPct = item.price > 0 ? (grossMargin / item.price) * 100 : 0;
+          return (
+            <div className="text-right">
+              <p className="font-semibold text-ink">{formatCurrency(grossMargin)}</p>
+              <p className="text-xs text-muted">{marginPct.toFixed(0)}% GM</p>
+            </div>
+          );
+        }
+      },
+      {
+        key: 'status',
+        header: 'Status',
+        align: 'right',
+        width: 120,
+        cell: (item) => lifecyclePill(item.status)
+      },
+      {
+        key: 'updated',
+        header: 'Updated',
+        align: 'right',
+        width: 180,
+        cell: (item) => (
+          <div className="text-right">
+            <p className="font-medium text-ink">{formatDate(item.lastUpdated)}</p>
+            <p className="text-xs text-muted">{item.location}</p>
+          </div>
+        )
+      }
+    ],
+    []
+  );
+
+  const modifierColumns = useMemo<DataTableColumn<ProductAdminModifierGroup>[]>(
+    () => [
+      {
+        key: 'group',
+        header: 'Modifier Group',
+        width: '30%',
+        cell: (group) => (
+          <div className="flex flex-col gap-1">
+            <span className="font-medium text-ink">{group.name}</span>
+            <span className="text-xs text-muted">
+              {group.required ? 'Required' : 'Optional'} • {group.options} options
+            </span>
+          </div>
+        )
+      },
+      {
+        key: 'appliesTo',
+        header: 'Attached To',
+        cell: (group) => (
+          <div className="flex flex-wrap gap-2">
+            {group.appliesTo.slice(0, 3).map((item) => (
+              <span
+                key={`${group.id}-${item}`}
+                className="inline-flex items-center rounded-full bg-surface-200 px-2 py-0.5 text-xs font-medium text-muted"
+              >
+                {item}
+              </span>
+            ))}
+            {group.appliesTo.length > 3 && (
+              <span className="text-xs text-muted">+{group.appliesTo.length - 3} more</span>
+            )}
+          </div>
+        )
+      },
+      {
+        key: 'itemsAttached',
+        header: 'Items',
+        align: 'right',
+        width: 100,
+        cell: (group) => (
+          <div className="text-right">
+            <p className="font-semibold text-ink">{group.itemsAttached}</p>
+            <p className="text-xs text-muted">linked</p>
+          </div>
+        )
+      },
+      {
+        key: 'status',
+        header: 'Status',
+        align: 'right',
+        width: 120,
+        cell: (group) => modifierStatusPill(group.status)
+      },
+      {
+        key: 'updated',
+        header: 'Updated',
+        align: 'right',
+        width: 200,
+        cell: (group) => (
+          <div className="text-right">
+            <p className="font-medium text-ink">{formatDate(group.lastUpdated)}</p>
+            <p className="text-xs text-muted">Last edit</p>
+          </div>
+        )
+      }
+    ],
+    []
+  );
+
+  const priceListColumns = useMemo<DataTableColumn<ProductAdminPriceList>[]>(
+    () => [
+      {
+        key: 'list',
+        header: 'Price List',
+        width: '30%',
+        cell: (list) => (
+          <div className="flex flex-col gap-1">
+            <span className="font-medium text-ink">{list.name}</span>
+            <span className="text-xs text-muted">{list.locations.join(', ')}</span>
+          </div>
+        )
+      },
+      {
+        key: 'channels',
+        header: 'Channels',
+        cell: (list) => (
+          <div className="flex flex-wrap gap-2">
+            {list.channels.map((channel) => (
+              <span
+                key={`${list.id}-${channel}`}
+                className="inline-flex items-center rounded-full bg-surface-200 px-2 py-0.5 text-xs font-medium text-muted"
+              >
+                {toTitleCase(channel)}
+              </span>
+            ))}
+          </div>
+        )
+      },
+      {
+        key: 'items',
+        header: 'Items',
+        align: 'right',
+        width: 100,
+        cell: (list) => (
+          <div className="text-right">
+            <p className="font-semibold text-ink">{list.items}</p>
+            <p className="text-xs text-muted">listed</p>
+          </div>
+        )
+      },
+      {
+        key: 'status',
+        header: 'Status',
+        align: 'right',
+        width: 120,
+        cell: (list) => priceListStatusPill(list.status)
+      },
+      {
+        key: 'effective',
+        header: 'Effective Dates',
+        align: 'right',
+        width: 220,
+        cell: (list) => (
+          <div className="text-right">
+            <p className="font-medium text-ink">From {formatDate(list.effectiveFrom)}</p>
+            <p className="text-xs text-muted">
+              {list.effectiveTo ? `Until ${formatDate(list.effectiveTo)}` : 'Continuous'}
+            </p>
+          </div>
+        )
+      },
+      {
+        key: 'synced',
+        header: 'Last Synced',
+        align: 'right',
+        width: 200,
+        cell: (list) => (
+          <div className="text-right">
+            <p className="font-medium text-ink">{formatDateTime(list.lastSynced)}</p>
+            <p className="text-xs text-muted">Most recent publish</p>
+          </div>
+        )
+      }
+    ],
+    []
+  );
+
+  const lastSyncedLabel = lastSyncedAt ? formatDateTime(lastSyncedAt) : 'Not synced yet';
+
+  const renderActiveTable = () => {
+    switch (activeTab) {
+      case 'items':
+        return (
+          <div className="space-y-3">
+            <DataTable<ProductAdminItem>
+              data={paginatedItems}
+              columns={itemColumns}
+              maxBodyHeight={420}
+              emptyState={
+                isLoading
+                  ? 'Loading item catalog…'
+                  : 'No items match your current filters.'
+              }
+            />
+            <DataTablePagination
+              page={currentItemsPage}
+              pageSize={pageSize.items}
+              totalItems={filteredItems.length}
+              onPageChange={(value) => handlePageChange('items', value)}
+              onPageSizeChange={(value) => handlePageSizeChange('items', value)}
+              pageSizeOptions={pageSizeOptions.items}
+              className="rounded-xl border border-line/60 bg-surface-100 shadow-card"
+            />
+          </div>
+        );
+      case 'modifiers':
+        return (
+          <div className="space-y-3">
+            <DataTable<ProductAdminModifierGroup>
+              data={paginatedModifiers}
+              columns={modifierColumns}
+              maxBodyHeight={420}
+              emptyState={
+                isLoading
+                  ? 'Loading modifier groups…'
+                  : 'No modifier groups match your filters.'
+              }
+            />
+            <DataTablePagination
+              page={currentModifiersPage}
+              pageSize={pageSize.modifiers}
+              totalItems={filteredModifiers.length}
+              onPageChange={(value) => handlePageChange('modifiers', value)}
+              onPageSizeChange={(value) => handlePageSizeChange('modifiers', value)}
+              pageSizeOptions={pageSizeOptions.modifiers}
+              className="rounded-xl border border-line/60 bg-surface-100 shadow-card"
+            />
+          </div>
+        );
+      case 'priceLists':
+        return (
+          <div className="space-y-3">
+            <DataTable<ProductAdminPriceList>
+              data={paginatedPriceLists}
+              columns={priceListColumns}
+              maxBodyHeight={420}
+              emptyState={
+                isLoading
+                  ? 'Loading price lists…'
+                  : 'No price lists match your filters.'
+              }
+            />
+            <DataTablePagination
+              page={currentPriceListsPage}
+              pageSize={pageSize.priceLists}
+              totalItems={filteredPriceLists.length}
+              onPageChange={(value) => handlePageChange('priceLists', value)}
+              onPageSizeChange={(value) => handlePageSizeChange('priceLists', value)}
+              pageSizeOptions={pageSizeOptions.priceLists}
+              className="rounded-xl border border-line/60 bg-surface-100 shadow-card"
+            />
+          </div>
+        );
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <MotionWrapper type="page" className="p-6">
+      <div className="mx-auto flex w-full max-w-7xl flex-col gap-6">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+          <div className="space-y-3">
+            <div>
+              <p className="text-sm font-semibold uppercase tracking-wide text-primary-600">
+                Products Admin
+              </p>
+              <h1 className="text-3xl font-bold text-ink">Products Dashboard</h1>
+            </div>
+            <p className="max-w-2xl text-sm text-muted">
+              Search and curate your menu catalog, manage modifier logic, and align price lists for
+              every channel. Use the filters below to focus on specific menu segments.
+            </p>
+          </div>
+
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-end">
+            <span className="text-xs font-medium uppercase tracking-wide text-muted">
+              Last synced {lastSyncedLabel}
+            </span>
+            <Button
+              type="button"
+              variant="outline"
+              className="flex items-center gap-2"
+              onClick={refresh}
+              disabled={isLoading}
+            >
+              <RefreshCcw size={16} />
+              Refresh data
+            </Button>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+          {summaryCards.map(({ id, label, value, meta, icon: Icon }) => (
+            <Card key={id} className="flex flex-col gap-3">
+              <div className="flex items-center justify-between">
+                <div className="p-2 rounded-lg bg-primary-100">
+                  <Icon size={20} className="text-primary-600" />
+                </div>
+                {renderStatusPill(`${value} total`, 'primary')}
+              </div>
+              <div>
+                <p className="text-sm font-medium text-muted uppercase tracking-wide">{label}</p>
+                <p className="text-2xl font-semibold text-ink">{value}</p>
+              </div>
+              <p className="text-xs text-muted">{meta}</p>
+            </Card>
+          ))}
+        </div>
+
+        <div className="flex flex-col gap-3 rounded-xl border border-line/60 bg-surface-100 p-4 shadow-card">
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+            <div className="flex flex-wrap items-center gap-2">
+              {tabs.map((tab) => {
+                const isActive = activeTab === tab.id;
+                return (
+                  <button
+                    key={tab.id}
+                    type="button"
+                    onClick={() => setActiveTab(tab.id)}
+                    className={cn(
+                      'inline-flex items-center gap-2 rounded-full border px-4 py-2 text-sm font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500/40',
+                      isActive
+                        ? 'border-primary-500 bg-primary-500 text-white shadow-card'
+                        : 'border-transparent bg-surface-200 text-ink hover:bg-surface-200/70'
+                    )}
+                  >
+                    <span>{tab.label}</span>
+                    <span
+                      className={cn(
+                        'rounded-full px-2 py-0.5 text-xs font-semibold',
+                        isActive ? 'bg-white/20 text-white' : 'bg-surface-100 text-muted'
+                      )}
+                    >
+                      {tabCounts[tab.id]}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+
+            <div className="w-full lg:w-72">
+              <div className="relative flex items-center">
+                <Search
+                  size={16}
+                  className="pointer-events-none absolute left-3 text-muted"
+                />
+                <input
+                  type="search"
+                  value={searchTerms[activeTab]}
+                  onChange={(event) => handleSearchChange(activeTab, event.target.value)}
+                  placeholder={searchPlaceholders[activeTab]}
+                  className="w-full rounded-lg border border-line bg-surface-100 py-2 pl-9 pr-3 text-sm text-ink placeholder:text-muted focus:border-primary-200 focus:outline-none focus:ring-2 focus:ring-primary-500/30"
+                />
+              </div>
+            </div>
+          </div>
+
+          <p className="text-sm text-muted">{tabs.find((tab) => tab.id === activeTab)?.description}</p>
+        </div>
+
+        {renderActiveTable()}
+      </div>
+    </MotionWrapper>
+  );
+};

--- a/src/components/ui/data-table/DataTable.tsx
+++ b/src/components/ui/data-table/DataTable.tsx
@@ -1,0 +1,161 @@
+import React from 'react';
+import { cn } from '@mas/utils';
+
+export type DataTableAlignment = 'left' | 'center' | 'right';
+
+export interface DataTableColumn<T> {
+  key: string;
+  header: React.ReactNode;
+  accessor?: keyof T;
+  cell?: (row: T) => React.ReactNode;
+  align?: DataTableAlignment;
+  width?: string | number;
+  headerClassName?: string;
+  cellClassName?: string;
+}
+
+const defaultGetRowId = <T,>(_: T, index: number) => index.toString();
+
+export interface DataTableProps<T> extends React.TableHTMLAttributes<HTMLTableElement> {
+  data: T[];
+  columns: Array<DataTableColumn<T>>;
+  getRowId?: (row: T, index: number) => string;
+  zebra?: boolean;
+  stickyHeader?: boolean;
+  emptyState?: React.ReactNode;
+  maxBodyHeight?: number | string;
+  scrollContainerClassName?: string;
+  bodyClassName?: string;
+}
+
+export const DataTable = <T,>({
+  data,
+  columns,
+  getRowId = defaultGetRowId,
+  zebra = true,
+  stickyHeader = true,
+  emptyState,
+  className,
+  maxBodyHeight,
+  scrollContainerClassName,
+  bodyClassName,
+  ...props
+}: DataTableProps<T>) => {
+  const scrollAreaStyle = React.useMemo(() => {
+    if (!maxBodyHeight) {
+      return undefined;
+    }
+
+    if (typeof maxBodyHeight === 'number') {
+      return { maxHeight: `${maxBodyHeight}px` } as React.CSSProperties;
+    }
+
+    return { maxHeight: maxBodyHeight } as React.CSSProperties;
+  }, [maxBodyHeight]);
+
+  return (
+    <div className="overflow-hidden rounded-xl border border-line/60 bg-surface-100 shadow-card">
+      <div className={cn('relative', scrollContainerClassName)}>
+        <div
+          className={cn('overflow-x-auto', maxBodyHeight && 'overflow-y-auto')}
+          style={scrollAreaStyle}
+        >
+          <table
+            className={cn(
+              'min-w-full border-separate border-spacing-0 text-left text-sm text-ink',
+              className
+            )}
+            {...props}
+          >
+            <thead
+              className={cn(
+                'text-xs font-semibold uppercase tracking-wide text-ink-70',
+                stickyHeader &&
+                  'sticky top-0 z-20 bg-surface-200/95 backdrop-blur supports-[backdrop-filter]:bg-surface-200/80 shadow-sm'
+              )}
+            >
+              <tr>
+                {columns.map((column) => (
+                  <th
+                    key={column.key}
+                    scope="col"
+                    style={
+                      column.width
+                        ? {
+                            width:
+                              typeof column.width === 'number'
+                                ? `${column.width}px`
+                                : column.width
+                          }
+                        : undefined
+                    }
+                    className={cn(
+                      'px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-ink-70',
+                      column.align === 'center' && 'text-center',
+                      column.align === 'right' && 'text-right',
+                      column.headerClassName
+                    )}
+                  >
+                    {column.header}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody className={cn('divide-y divide-line/60', bodyClassName)}>
+              {data.length === 0 ? (
+                <tr>
+                  <td
+                    colSpan={columns.length}
+                    className="px-4 py-10 text-center text-sm text-muted"
+                  >
+                    {emptyState ?? 'No records found.'}
+                  </td>
+                </tr>
+              ) : (
+                data.map((row, index) => {
+                  const rowId = getRowId(row, index);
+
+                  return (
+                    <tr
+                      key={rowId}
+                      className={cn(
+                        'transition-colors focus-within:bg-surface-200/70 hover:bg-surface-200/50',
+                        zebra
+                          ? 'odd:bg-surface-100 even:bg-surface-200/30'
+                          : 'bg-surface-100'
+                      )}
+                    >
+                      {columns.map((column) => {
+                        const cellContent = column.cell
+                          ? column.cell(row)
+                          : column.accessor
+                            ? ((row[column.accessor] as React.ReactNode) ?? null)
+                            : null;
+
+                        return (
+                          <td
+                            key={`${rowId}-${column.key}`}
+                            className={cn(
+                              'px-4 py-3 align-middle text-sm text-ink',
+                              column.align === 'center' && 'text-center',
+                              column.align === 'right' && 'text-right',
+                              column.cellClassName
+                            )}
+                          >
+                            {cellContent ?? <span className="text-muted">—</span>}
+                          </td>
+                        );
+                      })}
+                    </tr>
+                  );
+                })
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+DataTable.displayName = 'DataTable';

--- a/src/components/ui/data-table/DataTablePagination.tsx
+++ b/src/components/ui/data-table/DataTablePagination.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import { Button } from '@mas/ui';
+import { cn } from '@mas/utils';
+
+export interface DataTablePaginationProps {
+  page: number;
+  pageSize: number;
+  totalItems: number;
+  onPageChange: (page: number) => void;
+  onPageSizeChange?: (pageSize: number) => void;
+  pageSizeOptions?: number[];
+  className?: string;
+}
+
+export const DataTablePagination: React.FC<DataTablePaginationProps> = ({
+  page,
+  pageSize,
+  totalItems,
+  onPageChange,
+  onPageSizeChange,
+  pageSizeOptions = [5, 10, 20],
+  className
+}) => {
+  const totalPages = Math.max(1, Math.ceil(totalItems / pageSize));
+  const safePage = Math.min(page, totalPages);
+  const rangeStart = totalItems === 0 ? 0 : (safePage - 1) * pageSize + 1;
+  const rangeEnd = totalItems === 0 ? 0 : Math.min(totalItems, safePage * pageSize);
+
+  const handlePrevious = () => {
+    if (safePage > 1) {
+      onPageChange(safePage - 1);
+    }
+  };
+
+  const handleNext = () => {
+    if (safePage < totalPages) {
+      onPageChange(safePage + 1);
+    }
+  };
+
+  return (
+    <div
+      className={cn(
+        'flex flex-col gap-3 border-t border-line/60 bg-surface-100 px-4 py-3 text-sm md:flex-row md:items-center md:justify-between',
+        className
+      )}
+    >
+      <div className="text-muted">
+        {totalItems > 0
+          ? `Showing ${rangeStart}-${rangeEnd} of ${totalItems}`
+          : 'No records to display'}
+      </div>
+
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
+        {onPageSizeChange && (
+          <label className="flex items-center gap-2 text-sm text-muted">
+            <span className="hidden sm:inline">Rows per page</span>
+            <select
+              value={pageSize}
+              onChange={(event) => onPageSizeChange(Number(event.target.value))}
+              className="h-9 rounded-lg border border-line bg-surface-100 px-2 text-sm text-ink focus:border-primary-200 focus:outline-none focus:ring-2 focus:ring-primary-500/30"
+            >
+              {pageSizeOptions.map((option) => (
+                <option key={option} value={option}>
+                  {option}
+                </option>
+              ))}
+            </select>
+          </label>
+        )}
+
+        <div className="flex items-center justify-end gap-3">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={handlePrevious}
+            disabled={safePage <= 1}
+            className="min-w-[72px]"
+          >
+            Previous
+          </Button>
+
+          <span className="text-sm font-medium text-ink">
+            {safePage} <span className="text-muted">/ {totalPages}</span>
+          </span>
+
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={handleNext}
+            disabled={safePage >= totalPages}
+            className="min-w-[72px]"
+          >
+            Next
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+DataTablePagination.displayName = 'DataTablePagination';

--- a/src/components/ui/data-table/index.ts
+++ b/src/components/ui/data-table/index.ts
@@ -1,0 +1,2 @@
+export * from './DataTable';
+export * from './DataTablePagination';

--- a/src/data/mockProductsAdmin.ts
+++ b/src/data/mockProductsAdmin.ts
@@ -1,0 +1,329 @@
+export type ProductLifecycleStatus = 'active' | 'draft' | 'archived';
+export type ModifierGroupStatus = 'active' | 'draft' | 'retired';
+export type PriceListStatus = 'live' | 'scheduled' | 'expired';
+
+export interface ProductAdminItem {
+  id: string;
+  name: string;
+  sku: string;
+  category: string;
+  price: number;
+  cost: number;
+  status: ProductLifecycleStatus;
+  lastUpdated: string;
+  location: string;
+  tags: string[];
+  salesChannel: 'dine-in' | 'takeaway' | 'delivery' | 'all';
+}
+
+export interface ProductAdminModifierGroup {
+  id: string;
+  name: string;
+  status: ModifierGroupStatus;
+  required: boolean;
+  options: number;
+  itemsAttached: number;
+  appliesTo: string[];
+  lastUpdated: string;
+}
+
+export interface ProductAdminPriceList {
+  id: string;
+  name: string;
+  status: PriceListStatus;
+  currency: string;
+  items: number;
+  locations: string[];
+  channels: Array<'dine-in' | 'takeaway' | 'delivery' | 'marketplace'>;
+  effectiveFrom: string;
+  effectiveTo?: string;
+  lastSynced: string;
+}
+
+export const mockProductItems: ProductAdminItem[] = [
+  {
+    id: 'item-001',
+    name: 'Heritage Burger',
+    sku: 'BRG-001',
+    category: 'Mains',
+    price: 16.5,
+    cost: 5.25,
+    status: 'active',
+    lastUpdated: '2024-10-04T15:20:00Z',
+    location: 'Main Dining',
+    tags: ['Signature', 'Beef'],
+    salesChannel: 'all'
+  },
+  {
+    id: 'item-002',
+    name: 'Blackened Salmon',
+    sku: 'SEA-104',
+    category: 'Mains',
+    price: 24.0,
+    cost: 8.75,
+    status: 'active',
+    lastUpdated: '2024-10-03T12:05:00Z',
+    location: 'Chef Specials',
+    tags: ['Seafood', 'Dinner'],
+    salesChannel: 'dine-in'
+  },
+  {
+    id: 'item-003',
+    name: 'Truffle Fries',
+    sku: 'APP-208',
+    category: 'Shareables',
+    price: 9.5,
+    cost: 2.85,
+    status: 'active',
+    lastUpdated: '2024-10-01T19:44:00Z',
+    location: 'Bar Bites',
+    tags: ['Vegetarian'],
+    salesChannel: 'all'
+  },
+  {
+    id: 'item-004',
+    name: 'Seasonal Greens Salad',
+    sku: 'SAL-011',
+    category: 'Greens',
+    price: 13.0,
+    cost: 4.1,
+    status: 'active',
+    lastUpdated: '2024-09-30T08:15:00Z',
+    location: 'Main Dining',
+    tags: ['Gluten Free', 'Lunch'],
+    salesChannel: 'takeaway'
+  },
+  {
+    id: 'item-005',
+    name: 'Forest Mushroom Risotto',
+    sku: 'ENT-903',
+    category: 'Mains',
+    price: 21.5,
+    cost: 6.9,
+    status: 'draft',
+    lastUpdated: '2024-10-05T10:30:00Z',
+    location: 'Chef Lab',
+    tags: ['Vegetarian'],
+    salesChannel: 'dine-in'
+  },
+  {
+    id: 'item-006',
+    name: 'Citrus Olive Oil Cake',
+    sku: 'DES-304',
+    category: 'Desserts',
+    price: 8.5,
+    cost: 2.4,
+    status: 'active',
+    lastUpdated: '2024-09-29T18:40:00Z',
+    location: 'Pastry',
+    tags: ['Baked'],
+    salesChannel: 'all'
+  },
+  {
+    id: 'item-007',
+    name: 'Cold Brew Growler',
+    sku: 'BEV-712',
+    category: 'Beverages',
+    price: 18.0,
+    cost: 4.5,
+    status: 'active',
+    lastUpdated: '2024-10-02T07:50:00Z',
+    location: 'Cafe Window',
+    tags: ['Takeaway'],
+    salesChannel: 'takeaway'
+  },
+  {
+    id: 'item-008',
+    name: 'Korean Fried Cauliflower',
+    sku: 'APP-315',
+    category: 'Shareables',
+    price: 11.5,
+    cost: 3.9,
+    status: 'active',
+    lastUpdated: '2024-09-28T14:12:00Z',
+    location: 'Bar Bites',
+    tags: ['Spicy', 'Vegan'],
+    salesChannel: 'all'
+  },
+  {
+    id: 'item-009',
+    name: 'Charred Octopus',
+    sku: 'SEA-118',
+    category: 'Small Plates',
+    price: 17.0,
+    cost: 6.2,
+    status: 'draft',
+    lastUpdated: '2024-10-04T09:25:00Z',
+    location: 'Chef Specials',
+    tags: ['Seafood'],
+    salesChannel: 'dine-in'
+  },
+  {
+    id: 'item-010',
+    name: 'Ancient Grain Bowl',
+    sku: 'SAL-020',
+    category: 'Greens',
+    price: 15.5,
+    cost: 5.1,
+    status: 'active',
+    lastUpdated: '2024-10-01T11:33:00Z',
+    location: 'Main Dining',
+    tags: ['Vegan', 'Lunch'],
+    salesChannel: 'delivery'
+  },
+  {
+    id: 'item-011',
+    name: 'Tableside Guacamole',
+    sku: 'APP-119',
+    category: 'Shareables',
+    price: 12.0,
+    cost: 3.75,
+    status: 'archived',
+    lastUpdated: '2024-08-19T17:05:00Z',
+    location: 'Seasonal Archive',
+    tags: ['Summer'],
+    salesChannel: 'dine-in'
+  },
+  {
+    id: 'item-012',
+    name: 'Nitro Espresso Martini',
+    sku: 'BEV-745',
+    category: 'Beverages',
+    price: 13.0,
+    cost: 3.6,
+    status: 'active',
+    lastUpdated: '2024-09-26T21:48:00Z',
+    location: 'Bar Program',
+    tags: ['Cocktail'],
+    salesChannel: 'dine-in'
+  }
+];
+
+export const mockProductModifierGroups: ProductAdminModifierGroup[] = [
+  {
+    id: 'mod-001',
+    name: 'Protein Upgrades',
+    status: 'active',
+    required: false,
+    options: 5,
+    itemsAttached: 7,
+    appliesTo: ['Heritage Burger', 'Ancient Grain Bowl'],
+    lastUpdated: '2024-09-30T09:10:00Z'
+  },
+  {
+    id: 'mod-002',
+    name: 'Cooking Temperature',
+    status: 'active',
+    required: true,
+    options: 4,
+    itemsAttached: 5,
+    appliesTo: ['Blackened Salmon', 'Charred Octopus'],
+    lastUpdated: '2024-09-27T13:28:00Z'
+  },
+  {
+    id: 'mod-003',
+    name: 'Side Selections',
+    status: 'draft',
+    required: true,
+    options: 6,
+    itemsAttached: 9,
+    appliesTo: ['Heritage Burger', 'Forest Mushroom Risotto'],
+    lastUpdated: '2024-10-03T16:42:00Z'
+  },
+  {
+    id: 'mod-004',
+    name: 'Allergy Flags',
+    status: 'active',
+    required: false,
+    options: 8,
+    itemsAttached: 12,
+    appliesTo: ['Seasonal Greens Salad', 'Ancient Grain Bowl'],
+    lastUpdated: '2024-09-22T07:55:00Z'
+  },
+  {
+    id: 'mod-005',
+    name: 'Spice Scale',
+    status: 'active',
+    required: true,
+    options: 5,
+    itemsAttached: 6,
+    appliesTo: ['Korean Fried Cauliflower', 'Truffle Fries'],
+    lastUpdated: '2024-10-01T18:05:00Z'
+  },
+  {
+    id: 'mod-006',
+    name: 'Milk Alternatives',
+    status: 'retired',
+    required: false,
+    options: 4,
+    itemsAttached: 3,
+    appliesTo: ['Cold Brew Growler'],
+    lastUpdated: '2024-08-15T10:00:00Z'
+  }
+];
+
+export const mockProductPriceLists: ProductAdminPriceList[] = [
+  {
+    id: 'price-001',
+    name: 'Main Dining 2024',
+    status: 'live',
+    currency: 'USD',
+    items: 86,
+    locations: ['Main Dining Room'],
+    channels: ['dine-in'],
+    effectiveFrom: '2024-01-10T00:00:00Z',
+    lastSynced: '2024-10-05T06:45:00Z'
+  },
+  {
+    id: 'price-002',
+    name: 'Delivery Aggregators',
+    status: 'live',
+    currency: 'USD',
+    items: 54,
+    locations: ['Central Kitchen'],
+    channels: ['delivery', 'marketplace'],
+    effectiveFrom: '2024-03-01T00:00:00Z',
+    lastSynced: '2024-10-04T22:10:00Z'
+  },
+  {
+    id: 'price-003',
+    name: 'Seasonal Patio',
+    status: 'scheduled',
+    currency: 'USD',
+    items: 32,
+    locations: ['Rooftop Patio'],
+    channels: ['dine-in'],
+    effectiveFrom: '2024-11-15T00:00:00Z',
+    effectiveTo: '2025-03-15T00:00:00Z',
+    lastSynced: '2024-10-02T14:00:00Z'
+  },
+  {
+    id: 'price-004',
+    name: 'Café Daytime',
+    status: 'live',
+    currency: 'USD',
+    items: 41,
+    locations: ['Cafe Window'],
+    channels: ['takeaway'],
+    effectiveFrom: '2024-02-20T00:00:00Z',
+    lastSynced: '2024-10-03T08:20:00Z'
+  },
+  {
+    id: 'price-005',
+    name: 'Holiday Markets',
+    status: 'expired',
+    currency: 'USD',
+    items: 27,
+    locations: ['Pop-up Stand'],
+    channels: ['marketplace'],
+    effectiveFrom: '2023-11-05T00:00:00Z',
+    effectiveTo: '2024-01-02T00:00:00Z',
+    lastSynced: '2024-07-12T16:18:00Z'
+  }
+];
+
+export const mockProductsAdmin = {
+  items: mockProductItems,
+  modifierGroups: mockProductModifierGroups,
+  priceLists: mockProductPriceLists
+};

--- a/src/stores/productsAdminStore.ts
+++ b/src/stores/productsAdminStore.ts
@@ -1,0 +1,56 @@
+import { create } from 'zustand';
+import {
+  mockProductItems,
+  mockProductModifierGroups,
+  mockProductPriceLists,
+  ProductAdminItem,
+  ProductAdminModifierGroup,
+  ProductAdminPriceList
+} from '../data/mockProductsAdmin';
+
+interface ProductsAdminState {
+  items: ProductAdminItem[];
+  modifiers: ProductAdminModifierGroup[];
+  priceLists: ProductAdminPriceList[];
+  isLoading: boolean;
+  lastSyncedAt: string | null;
+  initialize: () => void;
+  refresh: () => void;
+}
+
+const loadMockDataset = () => ({
+  items: mockProductItems,
+  modifiers: mockProductModifierGroups,
+  priceLists: mockProductPriceLists
+});
+
+export const useProductsAdminStore = create<ProductsAdminState>((set, get) => ({
+  items: [],
+  modifiers: [],
+  priceLists: [],
+  isLoading: true,
+  lastSyncedAt: null,
+  initialize: () => {
+    const { items, modifiers, priceLists } = get();
+    if (items.length || modifiers.length || priceLists.length) {
+      set({ isLoading: false });
+      return;
+    }
+
+    const dataset = loadMockDataset();
+    set({
+      ...dataset,
+      isLoading: false,
+      lastSyncedAt: new Date().toISOString()
+    });
+  },
+  refresh: () => {
+    set({ isLoading: true });
+    const dataset = loadMockDataset();
+    set({
+      ...dataset,
+      isLoading: false,
+      lastSyncedAt: new Date().toISOString()
+    });
+  }
+}));


### PR DESCRIPTION
## Summary
- scaffold the Products dashboard with tabbed inventory, modifier, and price list tables plus search, pagination, and refresh controls
- extract reusable data table and pagination primitives with sticky headers and zebra striping for future admin surfaces
- seed the dashboard from mock datasets via a Zustand store and route /products to the new experience

## Testing
- npm run lint *(fails: pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cffb3616f88326b6ebcde6cb0f7fbf