### PR TITLE
Add KDS lanes with mock data and types

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -125,3 +125,15 @@
 - Log any issues needing backend fixes.  
 **Status:** TODO  
 **Log:**  
+
+---
+
+## Agent 11 — Kitchen Display System
+**Scope:** Build the KDS experience with live ticket lanes.
+**Tasks:**
+- Create KDS component with animated lanes and actionable tickets.
+- Provide supporting mock data and types.
+- Wire component into the shell using mocks.
+**Status:** DONE
+**Log:**
+- 2025-02-14: Implemented animated KDS lanes driven by new mock data/types and routed through App; lint check reports pre-existing issues in other modules (POS, Portal, PaperShader, StatusIndicator, themeStore).

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,11 +6,17 @@ import { Login } from './components/auth/Login';
 import { Portal } from './components/apps/Portal';
 import { POS } from './components/apps/POS';
 import { BackOffice } from './components/apps/BackOffice';
+import { KDS } from './components/apps/KDS';
+import {
+  mockKdsLanes,
+  mockKdsOrders,
+  mockKdsStationTags,
+  mockKdsTimers,
+} from './data/mockKds';
 import { useAuthStore } from './stores/authStore';
 import { useOfflineStore } from './stores/offlineStore';
 
 // Placeholder components for other apps
-const KDS = () => <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="p-6"><h2 className="text-2xl font-bold">Kitchen Display System</h2><p className="text-muted mt-2">Coming soon...</p></motion.div>;
 const Products = () => <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="p-6"><h2 className="text-2xl font-bold">Product Catalog</h2><p className="text-muted mt-2">Coming soon...</p></motion.div>;
 const Inventory = () => <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="p-6"><h2 className="text-2xl font-bold">Inventory Management</h2><p className="text-muted mt-2">Coming soon...</p></motion.div>;
 const Customers = () => <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="p-6"><h2 className="text-2xl font-bold">Customer Management</h2><p className="text-muted mt-2">Coming soon...</p></motion.div>;
@@ -57,7 +63,17 @@ function App() {
           <Route index element={<Navigate to="/portal" replace />} />
           <Route path="portal" element={<Portal />} />
           <Route path="pos" element={<POS />} />
-          <Route path="kds" element={<KDS />} />
+          <Route
+            path="kds"
+            element={
+              <KDS
+                orders={mockKdsOrders}
+                lanes={mockKdsLanes}
+                stationTags={mockKdsStationTags}
+                timers={mockKdsTimers}
+              />
+            }
+          />
           <Route path="products" element={<Products />} />
           <Route path="inventory" element={<Inventory />} />
           <Route path="customers" element={<Customers />} />

--- a/src/components/apps/KDS.tsx
+++ b/src/components/apps/KDS.tsx
@@ -1,0 +1,503 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { differenceInSeconds } from 'date-fns';
+import { AnimatePresence, useReducedMotion } from 'framer-motion';
+import { ArrowRight, Clock, RefreshCcw, TimerReset } from 'lucide-react';
+import { MotionWrapper } from '../ui/MotionWrapper';
+import type {
+  KdsLane,
+  KdsOrderItem,
+  KdsOrderStatus,
+  KdsOrderTicket,
+  KdsServiceType,
+  KdsStationTag,
+  KdsTimersConfig,
+} from '../../types/kds';
+
+interface KitchenDisplayProps {
+  orders: KdsOrderTicket[];
+  lanes: KdsLane[];
+  timers: KdsTimersConfig;
+  stationTags: KdsStationTag[];
+}
+
+type StationTagMap = Map<string, KdsStationTag>;
+
+const statusSequence: KdsOrderStatus[] = ['new', 'in-progress', 'ready'];
+
+const serviceTypeLabels: Record<KdsServiceType, string> = {
+  'dine-in': 'Dine-In',
+  takeaway: 'Takeaway',
+  delivery: 'Delivery',
+  curbside: 'Curbside',
+};
+
+const statusChipStyles: Record<KdsOrderStatus, string> = {
+  new: 'bg-[#EE766D]/20 text-[#24242E] border border-[#EE766D]/40',
+  'in-progress': 'bg-[#24242E] text-[#D6D6D6]',
+  ready: 'bg-[#D6D6D6] text-[#24242E]',
+};
+
+const serviceChipStyles: Record<KdsServiceType, string> = {
+  'dine-in': 'bg-[#24242E] text-[#D6D6D6]',
+  takeaway: 'bg-[#EE766D] text-[#24242E]',
+  delivery: 'bg-[#D6D6D6] text-[#24242E]',
+  curbside: 'bg-[#24242E] text-[#EE766D]',
+};
+
+const timerTone = (elapsedSeconds: number, timers: KdsTimersConfig) => {
+  if (elapsedSeconds >= timers.dangerSeconds) {
+    return 'text-danger';
+  }
+
+  if (elapsedSeconds >= timers.warningSeconds) {
+    return 'text-warning';
+  }
+
+  return 'text-success';
+};
+
+const formatSeconds = (value: number) => {
+  const absolute = Math.max(0, Math.abs(value));
+  const minutes = Math.floor(absolute / 60)
+    .toString()
+    .padStart(2, '0');
+  const seconds = Math.floor(absolute % 60)
+    .toString()
+    .padStart(2, '0');
+  return `${minutes}:${seconds}`;
+};
+
+const getNextStatus = (status: KdsOrderStatus): KdsOrderStatus | null => {
+  const index = statusSequence.indexOf(status);
+  if (index === -1 || index === statusSequence.length - 1) {
+    return null;
+  }
+
+  return statusSequence[index + 1];
+};
+
+const getPreviousStatus = (status: KdsOrderStatus): KdsOrderStatus | null => {
+  const index = statusSequence.indexOf(status);
+  if (index <= 0) {
+    return null;
+  }
+
+  return statusSequence[index - 1];
+};
+
+interface LaneColumnProps {
+  lane: KdsLane;
+  tickets: KdsOrderTicket[];
+  timers: KdsTimersConfig;
+  stationTagMap: StationTagMap;
+  onBump: (ticketId: string) => void;
+  onRecall: (ticketId: string) => void;
+}
+
+const LaneColumn: React.FC<LaneColumnProps> = ({
+  lane,
+  tickets,
+  timers,
+  stationTagMap,
+  onBump,
+  onRecall,
+}) => {
+  const reduceMotion = useReducedMotion();
+
+  const headerAccent = {
+    new: 'border-[#EE766D]/40',
+    'in-progress': 'border-[#24242E]/30',
+    ready: 'border-[#D6D6D6]/80',
+  }[lane.status];
+
+  const containerClass = `flex flex-col gap-4 rounded-lg bg-surface-100 border border-line/60 shadow-card p-4 min-h-[28rem] ${
+    headerAccent ?? ''
+  }`;
+
+  const content = (
+    <>
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h3 className="text-lg font-semibold text-[#24242E] flex items-center gap-2">
+            {lane.title}
+            <span
+              className={`text-xs font-medium px-2 py-0.5 rounded-full ${statusChipStyles[lane.status]}`}
+            >
+              {tickets.length} active
+            </span>
+          </h3>
+          {lane.description && (
+            <p className="text-sm text-muted mt-1 leading-snug">{lane.description}</p>
+          )}
+        </div>
+        <div className="text-right text-sm text-muted">
+          <p className="font-medium text-[#24242E]">{tickets.length}</p>
+          <p>Tickets</p>
+        </div>
+      </div>
+
+      <div className="space-y-3">
+        <AnimatePresence initial={false}>
+          {tickets.map((ticket) => (
+            reduceMotion ? (
+              <TicketCard
+                key={ticket.id}
+                ticket={ticket}
+                timers={timers}
+                stationTagMap={stationTagMap}
+                onBump={onBump}
+                onRecall={onRecall}
+              />
+            ) : (
+              <MotionWrapper key={ticket.id} type="card" layoutId={ticket.id} className="bg-white">
+                <TicketCard
+                  ticket={ticket}
+                  timers={timers}
+                  stationTagMap={stationTagMap}
+                  onBump={onBump}
+                  onRecall={onRecall}
+                />
+              </MotionWrapper>
+            )
+          ))}
+        </AnimatePresence>
+
+        {tickets.length === 0 && (
+          <div className="rounded-md border border-dashed border-line/70 bg-white/60 p-6 text-center text-sm text-muted">
+            No tickets in this lane.
+          </div>
+        )}
+      </div>
+    </>
+  );
+
+  if (reduceMotion) {
+    return <div className={containerClass}>{content}</div>;
+  }
+
+  return (
+    <MotionWrapper type="card" className={containerClass} layoutId={`lane-${lane.id}`}>
+      {content}
+    </MotionWrapper>
+  );
+};
+
+interface TicketCardProps {
+  ticket: KdsOrderTicket;
+  timers: KdsTimersConfig;
+  stationTagMap: StationTagMap;
+  onBump: (ticketId: string) => void;
+  onRecall: (ticketId: string) => void;
+}
+
+const TicketCard: React.FC<TicketCardProps> = ({
+  ticket,
+  timers,
+  stationTagMap,
+  onBump,
+  onRecall,
+}) => {
+  const elapsedSeconds = Math.max(0, differenceInSeconds(new Date(), new Date(ticket.startedAt)));
+  const remaining = ticket.prepSeconds - elapsedSeconds;
+  const tone = timerTone(elapsedSeconds, timers);
+  const formattedElapsed = formatSeconds(elapsedSeconds);
+  const formattedGoal = formatSeconds(ticket.prepSeconds);
+  const formattedRemaining = formatSeconds(Math.abs(remaining));
+
+  const showRecall = ticket.status === 'ready';
+
+  return (
+    <div className="rounded-lg border border-line/70 bg-white p-4 shadow-sm">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="space-y-1">
+          <div className="flex items-center gap-2">
+            <span className="text-xl font-semibold text-[#24242E]">#{ticket.orderNumber}</span>
+            <span
+              className={`text-xs font-medium px-2 py-0.5 rounded-full ${serviceChipStyles[ticket.serviceType]}`}
+            >
+              {serviceTypeLabels[ticket.serviceType]}
+            </span>
+            {ticket.isRush && (
+              <span className="text-xs font-semibold uppercase tracking-wide text-[#EE766D]">Rush</span>
+            )}
+          </div>
+          <div className="flex flex-wrap items-center gap-3 text-sm text-muted">
+            {ticket.tableNumber && <span>Table {ticket.tableNumber}</span>}
+            {ticket.destination && <span>{ticket.destination}</span>}
+            {ticket.guestName && <span>Guest: {ticket.guestName}</span>}
+          </div>
+        </div>
+
+        <div className={`flex items-center gap-2 text-sm font-medium ${tone}`}>
+          <Clock size={16} />
+          <span>{formattedElapsed}</span>
+          <span className="text-muted">/ {formattedGoal}</span>
+        </div>
+      </div>
+
+      {ticket.notes && (
+        <p className="mt-3 rounded-md bg-[#EE766D]/10 px-3 py-2 text-sm text-[#24242E]">
+          <TimerReset size={14} className="mr-2 inline text-[#EE766D]" />
+          {ticket.notes}
+        </p>
+      )}
+
+      <div className="mt-3 flex flex-wrap gap-2">
+        {ticket.stationTags.map((tagId) => {
+          const tag = stationTagMap.get(tagId);
+          if (!tag) {
+            return null;
+          }
+
+          return (
+            <span
+              key={`${ticket.id}-${tagId}`}
+              className="rounded-full px-3 py-1 text-xs font-medium"
+              style={{
+                backgroundColor: tag.background,
+                color: tag.foreground,
+              }}
+            >
+              {tag.label}
+            </span>
+          );
+        })}
+      </div>
+
+      <div className="mt-4 space-y-3">
+        {ticket.items.map((item) => (
+          <ItemRow key={item.id} item={item} stationTagMap={stationTagMap} />
+        ))}
+      </div>
+
+      <div className="mt-4 flex flex-wrap items-center justify-between gap-3 text-sm">
+        <div className="flex items-center gap-2 text-muted">
+          <ArrowRight size={16} className="text-[#EE766D]" />
+          <span className={remaining < 0 ? 'text-danger font-medium' : 'text-muted'}>
+            {remaining < 0 ? `Over by ${formattedRemaining}` : `Time left ${formattedRemaining}`}
+          </span>
+        </div>
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={() => onBump(ticket.id)}
+            className="flex items-center gap-2 rounded-md bg-[#EE766D] px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-[#d85f58] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#24242E]"
+          >
+            Bump
+            <ArrowRight size={16} />
+          </button>
+          {showRecall && (
+            <button
+              type="button"
+              onClick={() => onRecall(ticket.id)}
+              className="flex items-center gap-2 rounded-md border border-[#EE766D] px-4 py-2 text-sm font-medium text-[#EE766D] transition-colors hover:bg-[#EE766D]/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#24242E]"
+            >
+              <RefreshCcw size={16} />
+              Recall
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+interface ItemRowProps {
+  item: KdsOrderItem;
+  stationTagMap: StationTagMap;
+}
+
+const ItemRow: React.FC<ItemRowProps> = ({ item, stationTagMap }) => {
+  const tag = item.stationTag ? stationTagMap.get(item.stationTag) : undefined;
+  return (
+    <div className="rounded-md border border-line/50 bg-surface-200/40 p-3 text-sm text-[#24242E]">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <p className="font-semibold">
+            {item.quantity}× {item.name}
+          </p>
+          {item.modifiers && item.modifiers.length > 0 && (
+            <ul className="mt-1 list-disc space-y-0.5 pl-5 text-xs text-muted">
+              {item.modifiers.map((modifier) => (
+                <li key={modifier}>{modifier}</li>
+              ))}
+            </ul>
+          )}
+          {item.notes && <p className="mt-2 text-xs text-muted">{item.notes}</p>}
+        </div>
+        {tag && (
+          <span
+            className="rounded-full px-2 py-1 text-[11px] font-medium"
+            style={{
+              backgroundColor: tag.background,
+              color: tag.foreground,
+            }}
+          >
+            {tag.label}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export const KDS: React.FC<KitchenDisplayProps> = ({ orders, lanes, timers, stationTags }) => {
+  const [tickets, setTickets] = useState<KdsOrderTicket[]>(orders);
+
+  useEffect(() => {
+    setTickets(orders);
+  }, [orders]);
+
+  const stationTagMap = useMemo<StationTagMap>(() => {
+    return new Map(stationTags.map((tag) => [tag.id, tag]));
+  }, [stationTags]);
+
+  const ticketsByStatus = useMemo(() => {
+    const groups: Record<KdsOrderStatus, KdsOrderTicket[]> = {
+      new: [],
+      'in-progress': [],
+      ready: [],
+    };
+
+    tickets.forEach((ticket) => {
+      groups[ticket.status]?.push(ticket);
+    });
+
+    return groups;
+  }, [tickets]);
+
+  const countsByStatus = useMemo(() => {
+    const counts: Record<KdsOrderStatus, number> = {
+      new: 0,
+      'in-progress': 0,
+      ready: 0,
+    };
+
+    tickets.forEach((ticket) => {
+      counts[ticket.status] += 1;
+    });
+
+    return counts;
+  }, [tickets]);
+
+  const rushCount = useMemo(() => tickets.filter((ticket) => ticket.isRush).length, [tickets]);
+
+  const longestWaitingTicket = useMemo(() => {
+    if (tickets.length === 0) {
+      return null;
+    }
+
+    return tickets.reduce((longest, current) => {
+      if (!longest) {
+        return current;
+      }
+
+      const longestElapsed = differenceInSeconds(new Date(), new Date(longest.startedAt));
+      const currentElapsed = differenceInSeconds(new Date(), new Date(current.startedAt));
+
+      return currentElapsed > longestElapsed ? current : longest;
+    });
+  }, [tickets]);
+
+  const longestWaitSeconds = longestWaitingTicket
+    ? Math.max(0, differenceInSeconds(new Date(), new Date(longestWaitingTicket.startedAt)))
+    : 0;
+
+  const handleBump = useCallback((ticketId: string) => {
+    setTickets((prev) => {
+      const updated: KdsOrderTicket[] = [];
+
+      prev.forEach((ticket) => {
+        if (ticket.id !== ticketId) {
+          updated.push(ticket);
+          return;
+        }
+
+        const nextStatus = getNextStatus(ticket.status);
+        if (!nextStatus) {
+          return;
+        }
+
+        updated.push({
+          ...ticket,
+          status: nextStatus,
+          bumpedAt: nextStatus === 'ready' ? new Date().toISOString() : ticket.bumpedAt,
+        });
+      });
+
+      return updated;
+    });
+  }, []);
+
+  const handleRecall = useCallback((ticketId: string) => {
+    setTickets((prev) =>
+      prev.map((ticket) => {
+        if (ticket.id !== ticketId) {
+          return ticket;
+        }
+
+        const previous = getPreviousStatus(ticket.status);
+        if (!previous) {
+          return ticket;
+        }
+
+        return {
+          ...ticket,
+          status: previous,
+          bumpedAt: previous === 'ready' ? ticket.bumpedAt : undefined,
+        };
+      }),
+    );
+  }, []);
+
+  return (
+    <MotionWrapper type="page" className="p-6">
+      <div className="mx-auto max-w-7xl space-y-6">
+        <header className="flex flex-col gap-4 rounded-xl border border-line/60 bg-surface-100 p-6 shadow-card md:flex-row md:items-center md:justify-between">
+          <div>
+            <h1 className="text-3xl font-semibold text-[#24242E]">Kitchen Display</h1>
+            <p className="text-sm text-muted">Monitor the entire line at a glance and keep orders moving.</p>
+          </div>
+          <div className="flex flex-wrap gap-3">
+            {lanes.map((lane) => (
+              <div
+                key={lane.id}
+                className="flex min-w-[120px] flex-col rounded-lg border border-line/50 bg-white px-4 py-3 text-sm shadow-sm"
+              >
+                <span className="text-xs font-medium uppercase tracking-wide text-muted">{lane.title}</span>
+                <span className="text-2xl font-semibold text-[#24242E]">
+                  {countsByStatus[lane.status] ?? 0}
+                </span>
+              </div>
+            ))}
+            <div className="flex min-w-[120px] flex-col rounded-lg border border-[#EE766D]/40 bg-[#EE766D]/10 px-4 py-3 text-sm shadow-sm">
+              <span className="text-xs font-medium uppercase tracking-wide text-[#24242E]">Rush</span>
+              <span className="text-2xl font-semibold text-[#EE766D]">{rushCount}</span>
+            </div>
+            <div className="flex min-w-[140px] flex-col rounded-lg border border-line/50 bg-white px-4 py-3 text-sm shadow-sm">
+              <span className="text-xs font-medium uppercase tracking-wide text-muted">Longest Wait</span>
+              <span className="flex items-center gap-2 text-2xl font-semibold text-[#24242E]">
+                <Clock size={18} className="text-[#EE766D]" />
+                {formatSeconds(longestWaitSeconds)}
+              </span>
+            </div>
+          </div>
+        </header>
+
+        <div className="grid gap-6 md:grid-cols-3">
+          {lanes.map((lane) => (
+            <LaneColumn
+              key={lane.id}
+              lane={lane}
+              tickets={ticketsByStatus[lane.status] ?? []}
+              timers={timers}
+              stationTagMap={stationTagMap}
+              onBump={handleBump}
+              onRecall={handleRecall}
+            />
+          ))}
+        </div>
+      </div>
+    </MotionWrapper>
+  );
+};

--- a/src/data/mockKds.ts
+++ b/src/data/mockKds.ts
@@ -1,0 +1,267 @@
+import { subMinutes, subSeconds } from 'date-fns';
+import type {
+  KdsLane,
+  KdsOrderTicket,
+  KdsStationTag,
+  KdsTimersConfig,
+} from '../types/kds';
+
+const baseNow = new Date();
+
+const minutesAgo = (minutes: number) => subMinutes(baseNow, minutes).toISOString();
+const secondsAgo = (seconds: number) => subSeconds(baseNow, seconds).toISOString();
+
+export const mockKdsLanes: KdsLane[] = [
+  {
+    id: 'lane-new',
+    title: 'New',
+    status: 'new',
+    description: 'Freshly fired orders awaiting acknowledgement.',
+  },
+  {
+    id: 'lane-progress',
+    title: 'In Progress',
+    status: 'in-progress',
+    description: 'Tickets currently being prepared on the line.',
+  },
+  {
+    id: 'lane-ready',
+    title: 'Ready',
+    status: 'ready',
+    description: 'Completed plates waiting for pickup or running.',
+  },
+];
+
+export const mockKdsTimers: KdsTimersConfig = {
+  warningSeconds: 420,
+  dangerSeconds: 600,
+  readyGraceSeconds: 300,
+};
+
+export const mockKdsStationTags: KdsStationTag[] = [
+  {
+    id: 'expo',
+    label: 'Expo',
+    description: 'Window plating and handoff.',
+    background: '#24242E',
+    foreground: '#D6D6D6',
+  },
+  {
+    id: 'grill',
+    label: 'Grill',
+    description: 'Grill and flat-top station.',
+    background: '#EE766D',
+    foreground: '#24242E',
+  },
+  {
+    id: 'dessert',
+    label: 'Dessert',
+    description: 'Cold line desserts and plating.',
+    background: '#D6D6D6',
+    foreground: '#24242E',
+  },
+  {
+    id: 'bar',
+    label: 'Bar',
+    description: 'Beverage coordination.',
+    background: '#EE766D',
+    foreground: '#24242E',
+  },
+];
+
+export const mockKdsOrders: KdsOrderTicket[] = [
+  {
+    id: 'ticket-1042',
+    orderNumber: '1042',
+    status: 'new',
+    serviceType: 'dine-in',
+    tableNumber: '12',
+    guestName: 'Lopez',
+    startedAt: minutesAgo(2),
+    prepSeconds: 720,
+    stationTags: ['expo', 'grill'],
+    notes: 'Nut allergy: avoid cross contamination.',
+    items: [
+      {
+        id: 'item-1042-1',
+        name: 'Prime Burger',
+        quantity: 2,
+        modifiers: ['No onions', 'Medium rare'],
+        stationTag: 'grill',
+      },
+      {
+        id: 'item-1042-2',
+        name: 'House Fries',
+        quantity: 1,
+        modifiers: ['Truffle aioli on side'],
+        stationTag: 'expo',
+      },
+    ],
+  },
+  {
+    id: 'ticket-1045',
+    orderNumber: '1045',
+    status: 'new',
+    serviceType: 'takeaway',
+    destination: 'Pickup shelf A',
+    startedAt: minutesAgo(1),
+    prepSeconds: 540,
+    stationTags: ['expo'],
+    isRush: true,
+    items: [
+      {
+        id: 'item-1045-1',
+        name: 'Roasted Veggie Wrap',
+        quantity: 1,
+        modifiers: ['Spinach tortilla'],
+        stationTag: 'expo',
+      },
+      {
+        id: 'item-1045-2',
+        name: 'Seasonal Soup',
+        quantity: 1,
+        modifiers: ['Add bread roll'],
+        stationTag: 'expo',
+      },
+    ],
+  },
+  {
+    id: 'ticket-1049',
+    orderNumber: '1049',
+    status: 'new',
+    serviceType: 'delivery',
+    startedAt: minutesAgo(4),
+    prepSeconds: 900,
+    stationTags: ['grill', 'dessert'],
+    notes: 'Courier arriving at 7:15pm.',
+    items: [
+      {
+        id: 'item-1049-1',
+        name: 'Fire-Grilled Salmon',
+        quantity: 1,
+        modifiers: ['Gluten-free'],
+        stationTag: 'grill',
+      },
+      {
+        id: 'item-1049-2',
+        name: 'Key Lime Pie',
+        quantity: 1,
+        stationTag: 'dessert',
+      },
+    ],
+  },
+  {
+    id: 'ticket-1054',
+    orderNumber: '1054',
+    status: 'in-progress',
+    serviceType: 'dine-in',
+    tableNumber: '7',
+    startedAt: minutesAgo(8),
+    prepSeconds: 660,
+    stationTags: ['grill'],
+    items: [
+      {
+        id: 'item-1054-1',
+        name: 'Charred Ribeye',
+        quantity: 1,
+        modifiers: ['Medium'],
+        stationTag: 'grill',
+      },
+      {
+        id: 'item-1054-2',
+        name: 'Garlic Mash',
+        quantity: 1,
+        stationTag: 'expo',
+      },
+    ],
+  },
+  {
+    id: 'ticket-1056',
+    orderNumber: '1056',
+    status: 'in-progress',
+    serviceType: 'takeaway',
+    startedAt: minutesAgo(5),
+    prepSeconds: 600,
+    stationTags: ['expo'],
+    items: [
+      {
+        id: 'item-1056-1',
+        name: 'Chicken Pad Thai',
+        quantity: 2,
+        modifiers: ['Extra lime'],
+        stationTag: 'expo',
+      },
+    ],
+  },
+  {
+    id: 'ticket-1058',
+    orderNumber: '1058',
+    status: 'in-progress',
+    serviceType: 'curbside',
+    destination: 'Curb 3',
+    startedAt: minutesAgo(9),
+    prepSeconds: 780,
+    stationTags: ['expo', 'dessert'],
+    notes: 'Guest waiting outside.',
+    items: [
+      {
+        id: 'item-1058-1',
+        name: 'Fried Chicken Sandwich',
+        quantity: 2,
+        modifiers: ['No pickles'],
+        stationTag: 'expo',
+      },
+      {
+        id: 'item-1058-2',
+        name: 'Chocolate Mousse',
+        quantity: 2,
+        stationTag: 'dessert',
+      },
+    ],
+  },
+  {
+    id: 'ticket-1060',
+    orderNumber: '1060',
+    status: 'ready',
+    serviceType: 'dine-in',
+    tableNumber: '4',
+    startedAt: minutesAgo(12),
+    bumpedAt: secondsAgo(120),
+    prepSeconds: 780,
+    stationTags: ['expo'],
+    items: [
+      {
+        id: 'item-1060-1',
+        name: 'Chef Tasting Board',
+        quantity: 1,
+        modifiers: ['Add extra crostini'],
+        stationTag: 'expo',
+      },
+    ],
+  },
+  {
+    id: 'ticket-1062',
+    orderNumber: '1062',
+    status: 'ready',
+    serviceType: 'delivery',
+    startedAt: minutesAgo(14),
+    bumpedAt: secondsAgo(30),
+    prepSeconds: 840,
+    stationTags: ['expo', 'bar'],
+    destination: 'DoorDash - Alex',
+    items: [
+      {
+        id: 'item-1062-1',
+        name: 'Spicy Noodle Bowl',
+        quantity: 1,
+        stationTag: 'expo',
+      },
+      {
+        id: 'item-1062-2',
+        name: 'Thai Iced Tea',
+        quantity: 1,
+        stationTag: 'bar',
+      },
+    ],
+  },
+];

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -143,24 +143,6 @@ export interface CartItem extends OrderLine {
   variant?: ProductVariant;
 }
 
-export interface KdsTicket {
-  id: string;
-  orderId: string;
-  stationTag: string;
-  items: KdsItem[];
-  status: 'new' | 'in-progress' | 'done';
-  createdAt: Date;
-  estimatedTime?: number;
-}
-
-export interface KdsItem {
-  productName: string;
-  variantName?: string;
-  quantity: number;
-  modifiers: string[];
-  notes?: string;
-}
-
 // App routing
 export interface AppConfig {
   id: string;
@@ -189,3 +171,5 @@ export interface MotionPresets {
     duration: number;
   };
 }
+
+export * from './kds';

--- a/src/types/kds.ts
+++ b/src/types/kds.ts
@@ -1,0 +1,65 @@
+export type KdsOrderStatus = 'new' | 'in-progress' | 'ready';
+
+export type KdsServiceType = 'dine-in' | 'takeaway' | 'delivery' | 'curbside';
+
+export interface KdsStationTag {
+  id: string;
+  label: string;
+  description?: string;
+  /**
+   * Background color used when rendering the tag chip. Should reference the approved palette.
+   */
+  background: string;
+  /**
+   * Text color that maintains accessible contrast with the background.
+   */
+  foreground: string;
+}
+
+export interface KdsTimersConfig {
+  /**
+   * Number of seconds after which the timer should switch to a warning state.
+   */
+  warningSeconds: number;
+  /**
+   * Number of seconds after which the timer should switch to a danger state.
+   */
+  dangerSeconds: number;
+  /**
+   * Grace period (in seconds) before ready tickets auto-clear or require bumping.
+   */
+  readyGraceSeconds: number;
+}
+
+export interface KdsOrderItem {
+  id: string;
+  name: string;
+  quantity: number;
+  modifiers?: string[];
+  notes?: string;
+  stationTag?: string;
+}
+
+export interface KdsOrderTicket {
+  id: string;
+  orderNumber: string;
+  status: KdsOrderStatus;
+  serviceType: KdsServiceType;
+  tableNumber?: string;
+  guestName?: string;
+  destination?: string;
+  startedAt: string;
+  prepSeconds: number;
+  bumpedAt?: string;
+  isRush?: boolean;
+  notes?: string;
+  stationTags: string[];
+  items: KdsOrderItem[];
+}
+
+export interface KdsLane {
+  id: string;
+  title: string;
+  status: KdsOrderStatus;
+  description?: string;
+}


### PR DESCRIPTION
## Summary
- build a Kitchen Display System page with animated ticket lanes, timers, and bump/recall controls that respect reduced-motion settings
- add dedicated KDS mock data and type definitions and route the mock-fed component through the app shell
- log Agent 11 completion for the KDS scope

## Testing
- npm run lint *(fails: existing lint violations in POS.tsx, Portal.tsx, PaperShader.tsx, StatusIndicator.tsx, themeStore.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68cffb34bf5483268e04245d44fa561f