### PR TITLE
feat: add per-surface theme shader controls

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -118,10 +118,24 @@
 ---
 
 ## Agent 10 — Database/Functionality Checks
-**Scope:** Ensure functional logic and DB integration still work after UI changes.  
-**Tasks:**  
-- Verify forms still submit correctly.  
-- Confirm API/data fetching unaffected.  
-- Log any issues needing backend fixes.  
-**Status:** TODO  
-**Log:**  
+**Scope:** Ensure functional logic and DB integration still work after UI changes.
+**Tasks:**
+- Verify forms still submit correctly.
+- Confirm API/data fetching unaffected.
+- Log any issues needing backend fixes.
+**Status:** TODO
+**Log:**
+
+---
+
+## Agent 11 — Theme & Appearance Controls
+**Scope:** Theme store, shader behaviour, and appearance configuration panels.
+**Tasks:**
+- Extend theme persistence for per-surface shader controls.
+- Build BackOffice controls to tune shader settings live.
+- Ensure shader respects reduced motion preferences.
+- Sync settings with tenant/local storage mocks.
+**Status:** DONE
+**Log:**
+  - 2024-05-09: Reviewed current theme store and BackOffice UI. Planned per-surface schema for shader settings, migration strategy, and reduced-motion fallbacks.
+  - 2024-05-09: Implemented per-surface shader state with migration, updated PaperShader for reduced-motion/static fallback, refreshed BackOffice controls, and synced defaults with mock tenant/local storage. Global lint reports existing issues in POS/Portal/StatusIndicator outside this scope.

--- a/src/components/apps/BackOffice.tsx
+++ b/src/components/apps/BackOffice.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Card, Button } from '@mas/ui';
 import { useTheme } from '../../stores/themeStore';
+import { PaperSurface } from '../../types';
 
 const themeModes = [
   { id: 'light', label: 'Light' },
@@ -8,20 +9,51 @@ const themeModes = [
   { id: 'auto', label: 'Auto' },
 ] as const;
 
-const paperSurfaces: Array<'background' | 'cards'> = ['background', 'cards'];
+const paperSurfaces: Array<{ key: PaperSurface; label: string; description: string }> = [
+  {
+    key: 'background',
+    label: 'Background',
+    description: 'Covers the application shell and workspace backdrop.',
+  },
+  {
+    key: 'cards',
+    label: 'Cards & panels',
+    description: 'Applies to card components, sheets, and floating surfaces.',
+  },
+];
 
 export const BackOffice: React.FC = () => {
   const { mode, paperShader, setMode, updatePaperShader } = useTheme();
+  const [reduceMotion, setReduceMotion] = React.useState(false);
 
-  const toggleSurface = (surface: 'background' | 'cards') => {
-    const set = new Set(paperShader.surfaces);
-    if (set.has(surface)) {
-      set.delete(surface);
+  React.useEffect(() => {
+    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const handleChange = (event: MediaQueryListEvent) => setReduceMotion(event.matches);
+
+    setReduceMotion(mediaQuery.matches);
+
+    if ('addEventListener' in mediaQuery) {
+      mediaQuery.addEventListener('change', handleChange);
     } else {
-      set.add(surface);
+      mediaQuery.addListener(handleChange);
     }
-    const next = Array.from(set);
-    updatePaperShader({ surfaces: next.length ? next : ['background'] });
+
+    return () => {
+      if ('removeEventListener' in mediaQuery) {
+        mediaQuery.removeEventListener('change', handleChange);
+      } else {
+        mediaQuery.removeListener(handleChange);
+      }
+    };
+  }, []);
+
+  const toggleSurface = (surface: PaperSurface) => {
+    const current = paperShader.surfaces[surface];
+    updatePaperShader({
+      surfaces: {
+        [surface]: { enabled: !current.enabled },
+      },
+    });
   };
 
   return (
@@ -68,7 +100,7 @@ export const BackOffice: React.FC = () => {
               <div>
                 <h2 className="text-xl font-semibold">Paper Shader</h2>
                 <p className="text-muted text-sm">
-                  Toggle the tactile grain layer and fine-tune its intensity and animation speed.
+                  Tune tactile textures per surface. Animation speed of 0 keeps the layer static.
                 </p>
               </div>
               <Button
@@ -79,56 +111,99 @@ export const BackOffice: React.FC = () => {
               </Button>
             </div>
 
-            <div className="space-y-4">
-              <label className="flex flex-col gap-2">
-                <span className="text-sm font-medium text-ink">Grain intensity</span>
-                <input
-                  type="range"
-                  min={0}
-                  max={1}
-                  step={0.05}
-                  value={paperShader.intensity}
-                  onChange={(event) =>
-                    updatePaperShader({ intensity: parseFloat(event.target.value) })
-                  }
-                  className="w-full accent-primary-500"
-                />
-                <span className="text-xs text-muted">{paperShader.intensity.toFixed(2)}</span>
-              </label>
+            {reduceMotion && (
+              <div className="rounded-lg border border-dashed border-primary-400/60 bg-primary-50/60 p-3 text-sm text-primary-700">
+                Devices that prefer reduced motion render the shader as a static texture.
+              </div>
+            )}
 
-              <label className="flex flex-col gap-2">
-                <span className="text-sm font-medium text-ink">Animation speed</span>
-                <input
-                  type="range"
-                  min={0}
-                  max={3}
-                  step={0.1}
-                  value={paperShader.animationSpeed}
-                  onChange={(event) =>
-                    updatePaperShader({ animationSpeed: parseFloat(event.target.value) })
-                  }
-                  className="w-full accent-primary-500"
-                />
-                <span className="text-xs text-muted">{paperShader.animationSpeed.toFixed(1)}x</span>
-              </label>
+            <div className="space-y-5">
+              {paperSurfaces.map((surface) => {
+                const surfaceState = paperShader.surfaces[surface.key];
+                return (
+                  <div
+                    key={surface.key}
+                    className={`rounded-lg border border-line/60 bg-surface-100/80 p-4 space-y-4 ${
+                      paperShader.enabled ? '' : 'opacity-60'
+                    }`}
+                  >
+                    <div className="flex items-start justify-between gap-4">
+                      <div>
+                        <h3 className="text-base font-semibold text-ink">{surface.label}</h3>
+                        <p className="text-sm text-muted">{surface.description}</p>
+                      </div>
+                      <Button
+                        size="sm"
+                        variant={surfaceState.enabled ? 'primary' : 'outline'}
+                        onClick={() => toggleSurface(surface.key)}
+                      >
+                        {surfaceState.enabled ? 'Active' : 'Hidden'}
+                      </Button>
+                    </div>
+
+                    <div className="grid gap-4 md:grid-cols-2">
+                      <label className="flex flex-col gap-2">
+                        <span className="text-xs font-medium uppercase tracking-wide text-muted">
+                          Intensity
+                        </span>
+                        <input
+                          type="range"
+                          min={0}
+                          max={1}
+                          step={0.05}
+                          value={surfaceState.intensity}
+                          onChange={(event) =>
+                            updatePaperShader({
+                              surfaces: {
+                                [surface.key]: {
+                                  intensity: parseFloat(event.target.value),
+                                },
+                              },
+                            })
+                          }
+                          disabled={!surfaceState.enabled}
+                          className="w-full accent-primary-500"
+                        />
+                        <span className="text-xs text-muted">
+                          {surfaceState.intensity.toFixed(2)}
+                        </span>
+                      </label>
+
+                      <label className="flex flex-col gap-2">
+                        <span className="text-xs font-medium uppercase tracking-wide text-muted">
+                          Animation speed
+                        </span>
+                        <input
+                          type="range"
+                          min={0}
+                          max={3}
+                          step={0.1}
+                          value={surfaceState.animationSpeed}
+                          onChange={(event) =>
+                            updatePaperShader({
+                              surfaces: {
+                                [surface.key]: {
+                                  animationSpeed: parseFloat(event.target.value),
+                                },
+                              },
+                            })
+                          }
+                          disabled={!surfaceState.enabled}
+                          className="w-full accent-primary-500"
+                        />
+                        <span className="text-xs text-muted">
+                          {surfaceState.animationSpeed.toFixed(1)}x
+                          {surfaceState.animationSpeed === 0 ? ' · static' : ''}
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                );
+              })}
             </div>
 
-            <div>
-              <h3 className="text-sm font-medium text-ink mb-2">Apply shader to</h3>
-              <div className="flex flex-wrap gap-2">
-                {paperSurfaces.map((surface) => {
-                  const active = paperShader.surfaces.includes(surface);
-                  return (
-                    <Button
-                      key={surface}
-                      variant={active ? 'primary' : 'outline'}
-                      onClick={() => toggleSurface(surface)}
-                    >
-                      {surface === 'background' ? 'Background' : 'Cards'}
-                    </Button>
-                  );
-                })}
-              </div>
+            <div className="rounded-lg border border-line bg-surface-200/60 p-4 text-sm text-muted">
+              Settings persist per tenant and sync to local storage instantly.
             </div>
           </Card>
         </div>

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -18,20 +18,18 @@ export const AppShell: React.FC = () => {
   const navigate = useNavigate();
   const { user } = useAuthStore();
   const paperShader = useThemeStore((state) => state.paperShader);
+  const backgroundSurface = paperShader.surfaces.background;
 
   const currentApp = appConfigs.find((app) => location.pathname.startsWith(app.route));
   const isPortal = location.pathname === '/portal' || location.pathname === '/';
 
-  const shouldRenderPaper = paperShader.enabled && paperShader.surfaces.includes('background');
+  const shouldRenderPaper =
+    paperShader.enabled && backgroundSurface.enabled && backgroundSurface.intensity > 0;
 
   return (
     <div className="min-h-screen bg-bg-dust text-ink relative">
       {shouldRenderPaper && (
-        <PaperShader
-          intensity={paperShader.intensity}
-          animationSpeed={paperShader.animationSpeed}
-          surfaces={paperShader.surfaces}
-        />
+        <PaperShader surface="background" />
       )}
 
       <header className="bg-surface-100/80 backdrop-blur-sm border-b border-line sticky top-0 z-40">

--- a/src/data/mockData.ts
+++ b/src/data/mockData.ts
@@ -9,9 +9,18 @@ export const mockTenant: Tenant = {
     theme: 'light',
     paperShader: {
       enabled: true,
-      intensity: 0.5,
-      animationSpeed: 1.0,
-      surfaces: ['background', 'cards']
+      surfaces: {
+        background: {
+          enabled: true,
+          intensity: 0.5,
+          animationSpeed: 1.0
+        },
+        cards: {
+          enabled: true,
+          intensity: 0.35,
+          animationSpeed: 0
+        }
+      }
     }
   }
 };

--- a/src/providers/ThemeProvider.tsx
+++ b/src/providers/ThemeProvider.tsx
@@ -35,13 +35,15 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children }) => {
 
   useEffect(() => {
     const root = document.documentElement;
-    if (paperShader.surfaces.includes('cards') && paperShader.enabled) {
+    const cardSurface = paperShader.surfaces.cards;
+
+    if (paperShader.enabled && cardSurface.enabled) {
       root.dataset.paperCards = 'true';
     } else {
       delete root.dataset.paperCards;
     }
 
-    root.style.setProperty('--paper-card-opacity', (paperShader.intensity * 0.35).toFixed(3));
+    root.style.setProperty('--paper-card-opacity', cardSurface.intensity.toFixed(3));
   }, [paperShader]);
 
   useEffect(() => {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,16 +5,24 @@ export interface Tenant {
   settings: TenantSettings;
 }
 
+export type PaperSurface = 'background' | 'cards';
+
+export interface PaperShaderSurfaceSettings {
+  enabled: boolean;
+  intensity: number;
+  animationSpeed: number;
+}
+
+export interface PaperShaderSettings {
+  enabled: boolean;
+  surfaces: Record<PaperSurface, PaperShaderSurfaceSettings>;
+}
+
 export interface TenantSettings {
   currency: string;
   timezone: string;
   theme: 'light' | 'dark' | 'auto';
-  paperShader: {
-    enabled: boolean;
-    intensity: number;
-    animationSpeed: number;
-    surfaces: ('background' | 'cards')[];
-  };
+  paperShader: PaperShaderSettings;
 }
 
 export interface Store {


### PR DESCRIPTION
## Summary
- extend the theme store, types, and mock tenant data to persist per-surface paper shader settings with migration support
- update the PaperShader component, AppShell integration, and theme provider so reduced motion falls back to static textures while honoring per-surface controls
- refresh the BackOffice appearance panel with per-surface toggles, sliders, and reduced motion messaging for the shader layer

## Testing
- npm run lint *(fails: existing lint issues in POS, Portal, and StatusIndicator outside this scope)*

------
https://chatgpt.com/codex/tasks/task_e_68cfe8ce12948326864ad94c93f36447