### PR TITLE
Add catalog import wizard UI

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -118,10 +118,22 @@
 ---
 
 ## Agent 10 — Database/Functionality Checks
-**Scope:** Ensure functional logic and DB integration still work after UI changes.  
-**Tasks:**  
-- Verify forms still submit correctly.  
-- Confirm API/data fetching unaffected.  
-- Log any issues needing backend fixes.  
-**Status:** TODO  
-**Log:**  
+**Scope:** Ensure functional logic and DB integration still work after UI changes.
+**Tasks:**
+- Verify forms still submit correctly.
+- Confirm API/data fetching unaffected.
+- Log any issues needing backend fixes.
+**Status:** TODO
+**Log:**
+
+---
+
+## Agent 11 — Imports
+**Scope:** Data import wizard experience and reusable utilities.
+**Tasks:**
+- Build guided wizard for uploads, mapping, validation, and review.
+- Create reusable upload + column mapping UI modules.
+- Provide validation mocks and document outstanding warnings.
+**Status:** DONE
+**Log:**
+- Added multi-step import wizard with reusable upload/mapping components, validation mock workflow, and portal registration. No backend endpoints were impacted.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { Login } from './components/auth/Login';
 import { Portal } from './components/apps/Portal';
 import { POS } from './components/apps/POS';
 import { BackOffice } from './components/apps/BackOffice';
+import { ImportWizard } from './components/apps/imports/ImportWizard';
 import { useAuthStore } from './stores/authStore';
 import { useOfflineStore } from './stores/offlineStore';
 
@@ -59,6 +60,7 @@ function App() {
           <Route path="pos" element={<POS />} />
           <Route path="kds" element={<KDS />} />
           <Route path="products" element={<Products />} />
+          <Route path="imports" element={<ImportWizard />} />
           <Route path="inventory" element={<Inventory />} />
           <Route path="customers" element={<Customers />} />
           <Route path="promotions" element={<Promotions />} />

--- a/src/components/apps/imports/ImportWizard.tsx
+++ b/src/components/apps/imports/ImportWizard.tsx
@@ -1,0 +1,823 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+import {
+  AlertCircle,
+  AlertTriangle,
+  Check,
+  CheckCircle2,
+  ChevronLeft,
+  ChevronRight,
+  FileSpreadsheet,
+  Info,
+  Loader2,
+  ShieldCheck,
+} from 'lucide-react';
+import { MotionWrapper } from '../../ui/MotionWrapper';
+import { ImportUploadZone } from '../../ui/imports/ImportUploadZone';
+import {
+  ImportColumnMapper,
+  ImportColumnMapperProps,
+  ImportSourceColumn,
+  ImportTargetField,
+} from '../../ui/imports/ImportColumnMapper';
+
+interface ValidationIssue {
+  id: string;
+  row: number;
+  field: string;
+  message: string;
+  hint?: string;
+  type: 'error' | 'warning';
+}
+
+interface ValidationResponse {
+  summary: {
+    totalRows: number;
+    passed: number;
+    failed: number;
+    warnings: number;
+    skipped: number;
+    lastUpdated: string;
+  };
+  issues: ValidationIssue[];
+  samples: Array<{
+    row: number;
+    status: 'valid' | 'warning' | 'error';
+    values: Record<string, string>;
+    message?: string;
+  }>;
+}
+
+const TARGET_FIELDS: ImportTargetField[] = [
+  {
+    id: 'name',
+    label: 'Product name',
+    description: 'Displayed name for menus and order screens.',
+    example: 'House Salad',
+    required: true,
+  },
+  {
+    id: 'sku',
+    label: 'SKU / PLU',
+    description: 'Unique identifier used for reporting and kitchen routing.',
+    example: 'HS-001',
+    required: true,
+  },
+  {
+    id: 'category',
+    label: 'Category',
+    description: 'Groups products for menus, taxes, and analytics.',
+    example: 'Starters',
+    required: true,
+  },
+  {
+    id: 'price',
+    label: 'Price',
+    description: 'Base price before discounts.',
+    example: '12.50',
+    required: true,
+  },
+  {
+    id: 'cost',
+    label: 'Cost',
+    description: 'Optional cost of goods for profit analysis.',
+    example: '4.20',
+  },
+  {
+    id: 'stock',
+    label: 'On hand stock',
+    description: 'Quantity available for tracking inventory.',
+    example: '45',
+  },
+  {
+    id: 'status',
+    label: 'Status',
+    description: 'Determines if the product is active in menus.',
+    example: 'active',
+  },
+];
+
+const SOURCE_COLUMNS: ImportSourceColumn[] = [
+  { id: 'product_name', label: 'Product Name', sample: 'House Salad' },
+  { id: 'plu', label: 'PLU', sample: 'HS-001' },
+  { id: 'category_name', label: 'Category Name', sample: 'Starters' },
+  { id: 'base_price', label: 'Base Price', sample: '12.50' },
+  { id: 'cost_basis', label: 'Cost Basis', sample: '4.20' },
+  { id: 'quantity_on_hand', label: 'Quantity On Hand', sample: '45' },
+  { id: 'visibility', label: 'Visibility', sample: 'Active' },
+];
+
+const VALIDATION_MOCK: ValidationResponse = {
+  summary: {
+    totalRows: 120,
+    passed: 112,
+    failed: 5,
+    warnings: 3,
+    skipped: 0,
+    lastUpdated: 'moments ago',
+  },
+  issues: [
+    {
+      id: 'row-18-price',
+      row: 18,
+      field: 'Price',
+      message: 'Missing price value. Rows with empty prices cannot be imported.',
+      hint: 'Verify the spreadsheet includes a numeric value for each product price.',
+      type: 'error',
+    },
+    {
+      id: 'row-42-stock',
+      row: 42,
+      field: 'On hand stock',
+      message: 'Quantity appears unusually high (4,500 units).',
+      hint: 'Confirm the value or adjust to the correct inventory count.',
+      type: 'warning',
+    },
+    {
+      id: 'row-87-category',
+      row: 87,
+      field: 'Category',
+      message: 'Category “Seasonal Drinks” does not exist. It will be mapped to “Beverages”.',
+      hint: 'Create the category before importing if this mapping is incorrect.',
+      type: 'warning',
+    },
+  ],
+  samples: [
+    {
+      row: 6,
+      status: 'valid',
+      values: {
+        name: 'Garlic Knots',
+        sku: 'GN-006',
+        price: '5.00',
+      },
+      message: 'Ready to import.',
+    },
+    {
+      row: 18,
+      status: 'error',
+      values: {
+        name: 'Mushroom Risotto',
+        sku: 'MR-018',
+        price: '-',
+      },
+      message: 'Price missing. Row blocked until resolved.',
+    },
+    {
+      row: 42,
+      status: 'warning',
+      values: {
+        name: 'Holiday Blend Beans',
+        sku: 'HB-042',
+        price: '24.00',
+      },
+      message: 'Flagged for review due to high stock value.',
+    },
+  ],
+};
+
+const normalize = (value: string) => value.toLowerCase().replace(/[^a-z0-9]/g, '');
+
+const createEmptyMapping = (fields: ImportTargetField[]): Record<string, string | null> => {
+  return fields.reduce<Record<string, string | null>>((accumulator, field) => {
+    accumulator[field.id] = null;
+    return accumulator;
+  }, {});
+};
+
+type StepId = 'upload' | 'mapping' | 'validation' | 'review';
+
+const steps: Array<{ id: StepId; title: string; description: string }> = [
+  { id: 'upload', title: 'Upload', description: 'Bring in your spreadsheet or CSV export.' },
+  { id: 'mapping', title: 'Map columns', description: 'Connect spreadsheet columns to destination fields.' },
+  { id: 'validation', title: 'Validate', description: 'Run data checks to catch potential issues.' },
+  { id: 'review', title: 'Review', description: 'Confirm settings and start the import.' },
+];
+
+export const ImportWizard: React.FC = () => {
+  const [activeStep, setActiveStep] = React.useState(0);
+  const [file, setFile] = React.useState<File | null>(null);
+  const [uploadError, setUploadError] = React.useState<string | null>(null);
+  const [isUploading, setIsUploading] = React.useState(false);
+  const [mapping, setMapping] = React.useState<Record<string, string | null>>(() => createEmptyMapping(TARGET_FIELDS));
+  const [validationStatus, setValidationStatus] = React.useState<'idle' | 'running' | 'succeeded'>('idle');
+  const [validationState, setValidationState] = React.useState<ValidationResponse | null>(null);
+  const [resolvedIssues, setResolvedIssues] = React.useState<Set<string>>(() => new Set());
+  const [acknowledgeWarnings, setAcknowledgeWarnings] = React.useState(false);
+  const [isImporting, setIsImporting] = React.useState(false);
+  const [importComplete, setImportComplete] = React.useState(false);
+
+  const handleMappingChange: ImportColumnMapperProps['onChange'] = React.useCallback((fieldId, columnId) => {
+    setMapping((previous) => ({ ...previous, [fieldId]: columnId }));
+    setValidationStatus('idle');
+    setValidationState(null);
+    setResolvedIssues(new Set());
+  }, []);
+
+  const handleAutoMap = React.useCallback(() => {
+    const aliases: Record<string, string[]> = {
+      name: ['productname', 'itemname', 'menuitem'],
+      sku: ['sku', 'plu', 'code'],
+      category: ['category', 'department', 'group'],
+      price: ['price', 'baseprice', 'amount'],
+      cost: ['cost', 'cog', 'costbasis'],
+      stock: ['stock', 'quantity', 'quantityonhand'],
+      status: ['status', 'visibility', 'active'],
+    };
+
+    const normalizedColumns = SOURCE_COLUMNS.reduce<Record<string, string>>((accumulator, column) => {
+      accumulator[normalize(column.label)] = column.id;
+      return accumulator;
+    }, {});
+
+    setMapping((previous) => {
+      const next = { ...previous };
+
+      TARGET_FIELDS.forEach((field) => {
+        if (next[field.id]) {
+          return;
+        }
+
+        const candidates = [normalize(field.label), ...(aliases[field.id] ?? [])];
+        const match = candidates.find((candidate) => normalizedColumns[candidate]);
+
+        if (match) {
+          next[field.id] = normalizedColumns[match];
+        }
+      });
+
+      return next;
+    });
+  }, []);
+
+  const resetWizardState = React.useCallback(() => {
+    setActiveStep(0);
+    setMapping(createEmptyMapping(TARGET_FIELDS));
+    setValidationStatus('idle');
+    setValidationState(null);
+    setResolvedIssues(new Set());
+    setAcknowledgeWarnings(false);
+    setIsImporting(false);
+    setImportComplete(false);
+  }, []);
+
+  const handleFileSelect = React.useCallback((selectedFile: File) => {
+    const allowedExtensions = ['csv', 'xlsx'];
+    const extension = selectedFile.name.split('.').pop()?.toLowerCase();
+
+    if (!extension || !allowedExtensions.includes(extension)) {
+      setUploadError('Unsupported file type. Upload a CSV or Excel file.');
+      return;
+    }
+
+    setUploadError(null);
+    setIsUploading(true);
+
+    setTimeout(() => {
+      setFile(selectedFile);
+      setIsUploading(false);
+      resetWizardState();
+      handleAutoMap();
+    }, 600);
+  }, [handleAutoMap, resetWizardState]);
+
+  const handleRemoveFile = React.useCallback(() => {
+    setFile(null);
+    setUploadError(null);
+    resetWizardState();
+  }, [resetWizardState]);
+
+  const runValidation = React.useCallback(() => {
+    setValidationStatus('running');
+    setResolvedIssues(new Set());
+
+    setTimeout(() => {
+      setValidationState(VALIDATION_MOCK);
+      setValidationStatus('succeeded');
+    }, 800);
+  }, []);
+
+  const handleResolveIssue = React.useCallback((issueId: string) => {
+    setResolvedIssues((previous) => new Set(previous).add(issueId));
+  }, []);
+
+  const outstandingIssues = React.useMemo(() => {
+    if (!validationState) {
+      return [] as ValidationIssue[];
+    }
+
+    return validationState.issues.filter((issue) => !resolvedIssues.has(issue.id));
+  }, [resolvedIssues, validationState]);
+
+  const blockingIssues = React.useMemo(() => {
+    return outstandingIssues.filter((issue) => issue.type === 'error');
+  }, [outstandingIssues]);
+
+  const outstandingWarnings = React.useMemo(() => {
+    return outstandingIssues.filter((issue) => issue.type === 'warning');
+  }, [outstandingIssues]);
+
+  const mappingErrors = React.useMemo(() => {
+    const errors: Record<string, string> = {};
+    const assignments: Record<string, string> = {};
+    const fieldById = TARGET_FIELDS.reduce<Record<string, ImportTargetField>>((accumulator, field) => {
+      accumulator[field.id] = field;
+      return accumulator;
+    }, {});
+
+    TARGET_FIELDS.forEach((field) => {
+      const selectedColumn = mapping[field.id];
+
+      if (field.required && !selectedColumn) {
+        errors[field.id] = 'Map a source column before proceeding.';
+        return;
+      }
+
+      if (selectedColumn) {
+        if (assignments[selectedColumn]) {
+          const conflictField = assignments[selectedColumn];
+          errors[field.id] = `Already assigned to ${fieldById[conflictField].label}.`;
+          errors[conflictField] = `Already assigned to ${field.label}.`;
+        } else {
+          assignments[selectedColumn] = field.id;
+        }
+      }
+    });
+
+    return errors;
+  }, [mapping]);
+
+  const requiredMapped = React.useMemo(() => {
+    return TARGET_FIELDS.filter((field) => field.required).every((field) => Boolean(mapping[field.id]));
+  }, [mapping]);
+
+  const stepCompleted = React.useMemo(() => {
+    return {
+      upload: Boolean(file),
+      mapping: Boolean(file) && requiredMapped && Object.keys(mappingErrors).length === 0,
+      validation: validationStatus === 'succeeded' && blockingIssues.length === 0,
+      review: importComplete,
+    } satisfies Record<StepId, boolean>;
+  }, [file, requiredMapped, mappingErrors, validationStatus, blockingIssues.length, importComplete]);
+
+  const canGoNext = React.useMemo(() => {
+    if (activeStep === 0) {
+      return Boolean(file) && !isUploading;
+    }
+
+    if (activeStep === 1) {
+      return stepCompleted.mapping;
+    }
+
+    if (activeStep === 2) {
+      return validationStatus === 'succeeded' && blockingIssues.length === 0;
+    }
+
+    if (activeStep === 3) {
+      if (importComplete) {
+        return false;
+      }
+
+      if (outstandingWarnings.length > 0) {
+        return acknowledgeWarnings && !isImporting;
+      }
+
+      return !isImporting;
+    }
+
+    return false;
+  }, [activeStep, acknowledgeWarnings, blockingIssues.length, file, importComplete, isImporting, isUploading, outstandingWarnings.length, stepCompleted.mapping, validationStatus]);
+
+  const handleBack = () => {
+    setActiveStep((previous) => Math.max(previous - 1, 0));
+  };
+
+  const handleNext = () => {
+    if (activeStep === steps.length - 1) {
+      setIsImporting(true);
+      setTimeout(() => {
+        setIsImporting(false);
+        setImportComplete(true);
+      }, 1000);
+      return;
+    }
+
+    setActiveStep((previous) => Math.min(previous + 1, steps.length - 1));
+  };
+
+  const primaryButtonLabel = React.useMemo(() => {
+    if (activeStep === steps.length - 1) {
+      if (importComplete) {
+        return 'Import completed';
+      }
+      if (isImporting) {
+        return 'Importing…';
+      }
+      return 'Start import';
+    }
+
+    return 'Next';
+  }, [activeStep, importComplete, isImporting]);
+
+  const renderStepper = () => (
+    <div className="grid gap-4 md:grid-cols-4">
+      {steps.map((step, index) => {
+        const status = stepCompleted[step.id]
+          ? 'complete'
+          : index === activeStep
+          ? 'current'
+          : 'upcoming';
+
+        return (
+          <div
+            key={step.id}
+            className={`rounded-xl border px-4 py-3 transition-colors ${
+              status === 'complete'
+                ? 'border-success/40 bg-success/10'
+                : status === 'current'
+                ? 'border-primary-200 bg-primary-100/40'
+                : 'border-line bg-surface-100'
+            }`}
+          >
+            <div className="flex items-center gap-3">
+              <div
+                className={`flex h-10 w-10 items-center justify-center rounded-full border text-sm font-semibold ${
+                  status === 'complete'
+                    ? 'border-success/40 bg-success text-white'
+                    : status === 'current'
+                    ? 'border-primary-200 bg-white text-primary-600'
+                    : 'border-line bg-white text-muted'
+                }`}
+              >
+                {status === 'complete' ? <Check className="h-5 w-5" /> : index + 1}
+              </div>
+
+              <div>
+                <p className="text-sm font-semibold text-ink">{step.title}</p>
+                <p className="text-xs text-muted">{step.description}</p>
+              </div>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+
+  const renderUploadStep = () => (
+    <div className="space-y-6">
+      <div className="rounded-xl border border-line bg-surface-100/60 p-6">
+        <div className="mb-4">
+          <h2 className="text-xl font-semibold text-ink">Upload your data file</h2>
+          <p className="text-sm text-muted">
+            Accepts CSV or Excel exports from your catalog system. We never import data automatically without your
+            confirmation.
+          </p>
+        </div>
+
+        <ImportUploadZone
+          file={file}
+          error={uploadError ?? undefined}
+          helperText="We recommend keeping file sizes under 10MB for faster validation."
+          isUploading={isUploading}
+          onFileSelect={handleFileSelect}
+          onRemoveFile={handleRemoveFile}
+        />
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <div className="rounded-xl border border-line bg-surface-100/60 p-5">
+          <h3 className="text-sm font-semibold text-ink">Tips for a clean import</h3>
+          <ul className="mt-3 space-y-2 text-sm text-muted">
+            <li>• Remove summary rows or totals so we only import product lines.</li>
+            <li>• Ensure column headers are on the first row of your file.</li>
+            <li>• Dates and numbers should be formatted consistently.</li>
+          </ul>
+        </div>
+
+        <div className="rounded-xl border border-line bg-surface-100/60 p-5">
+          <h3 className="text-sm font-semibold text-ink">Need a template?</h3>
+          <p className="mt-2 text-sm text-muted">
+            Download the import template to see required columns and sample data formatting.
+          </p>
+          <button
+            type="button"
+            className="mt-4 inline-flex items-center gap-2 rounded-lg border border-primary-200 bg-white px-4 py-2 text-sm font-medium text-primary-600 transition hover:bg-primary-100/50"
+          >
+            <FileSpreadsheet className="h-4 w-4" />
+            Download template
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+
+  const renderMappingStep = () => (
+    <div className="rounded-xl border border-line bg-surface-100/70 p-6">
+      <ImportColumnMapper
+        sourceColumns={SOURCE_COLUMNS}
+        targetFields={TARGET_FIELDS}
+        mapping={mapping}
+        errors={mappingErrors}
+        onChange={handleMappingChange}
+        onAutoMap={handleAutoMap}
+      />
+    </div>
+  );
+
+  const renderValidationStep = () => (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-3 rounded-xl border border-line bg-surface-100/70 p-6 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h3 className="text-lg font-semibold text-ink">Validate data quality</h3>
+          <p className="text-sm text-muted">
+            We check required fields, number formatting, duplicates, and category availability before importing.
+          </p>
+        </div>
+
+        <button
+          type="button"
+          onClick={runValidation}
+          disabled={validationStatus === 'running'}
+          className="inline-flex items-center gap-2 rounded-lg bg-primary-500 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-primary-600 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {validationStatus === 'running' ? <Loader2 className="h-4 w-4 animate-spin" /> : <ShieldCheck className="h-4 w-4" />}
+          {validationStatus === 'idle' ? 'Run validation' : 'Re-run validation'}
+        </button>
+      </div>
+
+      {validationStatus === 'idle' && !validationState && (
+        <div className="rounded-xl border border-dashed border-line bg-surface-100/60 p-6 text-sm text-muted">
+          Run validation to generate a quality report. We create a mock response in this demo so you can preview the workflow.
+        </div>
+      )}
+
+      {validationStatus === 'running' && (
+        <div className="flex items-center gap-3 rounded-xl border border-line bg-surface-100/70 p-5 text-sm text-muted">
+          <Loader2 className="h-4 w-4 animate-spin text-primary-500" />
+          Checking column formats, required values, and duplicates...
+        </div>
+      )}
+
+      {validationState && (
+        <div className="space-y-6">
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+            <div className="rounded-lg border border-line bg-white/70 p-4">
+              <p className="text-xs font-semibold uppercase tracking-wide text-muted">Total rows</p>
+              <p className="mt-2 text-2xl font-semibold text-ink">{validationState.summary.totalRows}</p>
+            </div>
+            <div className="rounded-lg border border-line bg-white/70 p-4">
+              <p className="text-xs font-semibold uppercase tracking-wide text-muted">Passed</p>
+              <p className="mt-2 text-2xl font-semibold text-success">{validationState.summary.passed}</p>
+            </div>
+            <div className="rounded-lg border border-line bg-white/70 p-4">
+              <p className="text-xs font-semibold uppercase tracking-wide text-muted">Warnings</p>
+              <p className="mt-2 text-2xl font-semibold text-warning">{validationState.summary.warnings}</p>
+            </div>
+            <div className="rounded-lg border border-line bg-white/70 p-4">
+              <p className="text-xs font-semibold uppercase tracking-wide text-muted">Blocked</p>
+              <p className="mt-2 text-2xl font-semibold text-danger">{validationState.summary.failed}</p>
+            </div>
+          </div>
+
+          {outstandingIssues.length > 0 ? (
+            <div className="space-y-3">
+              {outstandingIssues.map((issue) => {
+                const isError = issue.type === 'error';
+                return (
+                  <div
+                    key={issue.id}
+                    className={`rounded-xl border px-4 py-3 ${
+                      isError
+                        ? 'border-danger/50 bg-danger/10 text-danger'
+                        : 'border-warning/40 bg-warning/10 text-warning'
+                    }`}
+                  >
+                    <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                      <div className="flex flex-1 items-start gap-3">
+                        {isError ? (
+                          <AlertCircle className="mt-0.5 h-5 w-5" />
+                        ) : (
+                          <AlertTriangle className="mt-0.5 h-5 w-5" />
+                        )}
+                        <div>
+                          <p className="text-sm font-semibold text-ink">Row {issue.row} • {issue.field}</p>
+                          <p className="mt-1 text-sm">{issue.message}</p>
+                          {issue.hint && <p className="mt-2 text-xs text-ink/80">{issue.hint}</p>}
+                        </div>
+                      </div>
+
+                      <button
+                        type="button"
+                        onClick={() => handleResolveIssue(issue.id)}
+                        className={`inline-flex items-center gap-2 rounded-lg border px-3 py-1.5 text-xs font-semibold transition ${
+                          isError
+                            ? 'border-danger/40 text-danger hover:bg-danger/20'
+                            : 'border-warning/40 text-warning hover:bg-warning/20'
+                        }`}
+                      >
+                        <CheckCircle2 className="h-4 w-4" />
+                        Mark resolved
+                      </button>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          ) : (
+            <div className="flex items-center gap-3 rounded-xl border border-success/30 bg-success/10 px-4 py-3 text-sm text-success">
+              <CheckCircle2 className="h-5 w-5" />
+              No outstanding validation issues. You are ready to proceed.
+            </div>
+          )}
+
+          <div className="rounded-xl border border-line overflow-hidden">
+            <div className="bg-surface-200 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-muted">
+              Sample rows
+            </div>
+            {validationState.samples.map((sample) => (
+              <div
+                key={sample.row}
+                className="flex flex-col gap-3 border-t border-line/60 px-4 py-3 sm:flex-row sm:items-center sm:justify-between"
+              >
+                <div>
+                  <p className="text-sm font-semibold text-ink">Row {sample.row}</p>
+                  <p className="mt-1 text-xs text-muted">{sample.message}</p>
+                </div>
+                <div className="flex flex-wrap gap-3 text-xs text-muted">
+                  {Object.entries(sample.values).map(([key, value]) => (
+                    <span key={key} className="rounded-full bg-surface-200 px-3 py-1 font-medium text-ink">
+                      {key}: {value}
+                    </span>
+                  ))}
+                </div>
+                <div
+                  className={`inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wide ${
+                    sample.status === 'valid'
+                      ? 'bg-success/10 text-success'
+                      : sample.status === 'warning'
+                      ? 'bg-warning/10 text-warning'
+                      : 'bg-danger/10 text-danger'
+                  }`}
+                >
+                  {sample.status === 'valid' ? (
+                    <CheckCircle2 className="h-4 w-4" />
+                  ) : sample.status === 'warning' ? (
+                    <AlertTriangle className="h-4 w-4" />
+                  ) : (
+                    <AlertCircle className="h-4 w-4" />
+                  )}
+                  {sample.status}
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {blockingIssues.length > 0 && (
+            <div className="flex items-start gap-3 rounded-xl border border-danger/50 bg-danger/10 px-4 py-3 text-sm text-danger">
+              <AlertCircle className="mt-0.5 h-4 w-4 flex-shrink-0" />
+              Resolve blocking errors before continuing. Adjust column mappings or update the source data, then re-run validation.
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+
+  const renderReviewStep = () => (
+    <div className="space-y-6">
+      <div className="rounded-xl border border-line bg-surface-100/70 p-6">
+        <h3 className="text-lg font-semibold text-ink">Review import summary</h3>
+        <p className="text-sm text-muted">Confirm everything looks good before we write data to your catalog.</p>
+
+        <div className="mt-6 grid gap-4 md:grid-cols-2">
+          <div className="rounded-lg border border-line bg-white/70 p-4">
+            <p className="text-xs font-semibold uppercase tracking-wide text-muted">File selected</p>
+            {file ? (
+              <div className="mt-2 text-sm text-ink">
+                <p className="font-semibold">{file.name}</p>
+                <p className="text-muted">{(file.size / 1024).toFixed(1)} KB</p>
+              </div>
+            ) : (
+              <p className="mt-2 text-sm text-muted">No file selected.</p>
+            )}
+          </div>
+
+          <div className="rounded-lg border border-line bg-white/70 p-4">
+            <p className="text-xs font-semibold uppercase tracking-wide text-muted">Validation status</p>
+            {validationStatus === 'succeeded' ? (
+              <p className="mt-2 flex items-center gap-2 text-sm font-semibold text-success">
+                <CheckCircle2 className="h-4 w-4" /> Ready for import
+              </p>
+            ) : (
+              <p className="mt-2 text-sm text-muted">Run validation to confirm data quality.</p>
+            )}
+            {outstandingWarnings.length > 0 && (
+              <p className="mt-2 text-xs text-warning">
+                {outstandingWarnings.length} warning{outstandingWarnings.length === 1 ? '' : 's'} will be acknowledged.
+              </p>
+            )}
+          </div>
+        </div>
+
+        <div className="mt-6">
+          <p className="text-xs font-semibold uppercase tracking-wide text-muted">Column mapping</p>
+          <div className="mt-3 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {TARGET_FIELDS.map((field) => {
+              const columnId = mapping[field.id];
+              const column = SOURCE_COLUMNS.find((source) => source.id === columnId);
+
+              return (
+                <div key={field.id} className="rounded-lg border border-line bg-white/70 p-3">
+                  <p className="text-xs font-semibold uppercase tracking-wide text-muted">{field.label}</p>
+                  <p className="mt-1 text-sm font-medium text-ink">{column ? column.label : 'Not mapped'}</p>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        {outstandingWarnings.length > 0 && (
+          <label className="mt-6 flex items-start gap-3 rounded-lg border border-warning/50 bg-warning/10 px-4 py-3 text-sm text-warning">
+            <input
+              type="checkbox"
+              checked={acknowledgeWarnings}
+              onChange={(event) => setAcknowledgeWarnings(event.target.checked)}
+              className="mt-1 h-4 w-4 rounded border-warning/60 text-warning focus:ring-warning"
+            />
+            <span>
+              I understand that {outstandingWarnings.length} warning{outstandingWarnings.length === 1 ? '' : 's'} remain and want to
+              continue with the import.
+            </span>
+          </label>
+        )}
+
+        {importComplete && (
+          <motion.div
+            initial={{ opacity: 0, y: 8 }}
+            animate={{ opacity: 1, y: 0 }}
+            className="mt-6 flex items-center gap-3 rounded-lg border border-success/40 bg-success/10 px-4 py-3 text-success"
+          >
+            <CheckCircle2 className="h-5 w-5" /> Import complete. You can review newly created items in the product catalog.
+          </motion.div>
+        )}
+      </div>
+    </div>
+  );
+
+  return (
+    <MotionWrapper type="page" className="p-6">
+      <div className="mx-auto flex max-w-6xl flex-col gap-6">
+        <div className="flex flex-col gap-2">
+          <p className="text-xs font-semibold uppercase tracking-wide text-primary-600">Data imports</p>
+          <h1 className="text-3xl font-bold text-ink">Catalog import wizard</h1>
+          <p className="text-muted">
+            Step through the guided flow to upload a spreadsheet, map columns, validate quality, and review changes before
+            writing to your workspace.
+          </p>
+        </div>
+
+        {renderStepper()}
+
+        <div className="rounded-2xl border border-line bg-surface-100/70 p-6">
+          {activeStep === 0 && renderUploadStep()}
+          {activeStep === 1 && renderMappingStep()}
+          {activeStep === 2 && renderValidationStep()}
+          {activeStep === 3 && renderReviewStep()}
+
+          <div className="mt-8 flex flex-col gap-3 border-t border-line/60 pt-6 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex items-center gap-2 text-xs text-muted">
+              <Info className="h-4 w-4" />
+              {activeStep < 3 ? 'You can revisit previous steps at any time.' : 'Confirmed data is written to your catalog instantly.'}
+            </div>
+
+            <div className="flex flex-wrap gap-3">
+              <button
+                type="button"
+                onClick={handleBack}
+                disabled={activeStep === 0}
+                className="inline-flex items-center gap-2 rounded-lg border border-line bg-white px-4 py-2 text-sm font-semibold text-ink transition hover:border-primary-200 hover:text-primary-600 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                <ChevronLeft className="h-4 w-4" />
+                Back
+              </button>
+
+              <button
+                type="button"
+                onClick={handleNext}
+                disabled={!canGoNext}
+                className="inline-flex items-center gap-2 rounded-lg bg-primary-500 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-primary-600 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {activeStep === steps.length - 1 ? (
+                  <ShieldCheck className="h-4 w-4" />
+                ) : (
+                  <ChevronRight className="h-4 w-4" />
+                )}
+                {primaryButtonLabel}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </MotionWrapper>
+  );
+};

--- a/src/components/ui/imports/ImportColumnMapper.tsx
+++ b/src/components/ui/imports/ImportColumnMapper.tsx
@@ -1,0 +1,152 @@
+import React from 'react';
+import { AlertCircle, CheckCircle2, Sparkles } from 'lucide-react';
+
+export interface ImportSourceColumn {
+  id: string;
+  label: string;
+  sample?: string;
+}
+
+export interface ImportTargetField {
+  id: string;
+  label: string;
+  description?: string;
+  example?: string;
+  required?: boolean;
+}
+
+export interface ImportColumnMapperProps {
+  sourceColumns: ImportSourceColumn[];
+  targetFields: ImportTargetField[];
+  mapping: Record<string, string | null>;
+  errors?: Record<string, string | undefined>;
+  onChange: (fieldId: string, columnId: string | null) => void;
+  onAutoMap?: () => void;
+}
+
+export const ImportColumnMapper: React.FC<ImportColumnMapperProps> = ({
+  errors,
+  mapping,
+  onAutoMap,
+  onChange,
+  sourceColumns,
+  targetFields,
+}) => {
+  const hasErrors = errors && Object.values(errors).some(Boolean);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h3 className="text-lg font-semibold">Map columns to data fields</h3>
+          <p className="text-sm text-muted">
+            Pair each destination field with a column from your uploaded file. Required fields must be mapped
+            before continuing.
+          </p>
+        </div>
+
+        {onAutoMap && (
+          <button
+            type="button"
+            onClick={onAutoMap}
+            className="inline-flex items-center gap-2 self-start rounded-lg border border-line bg-surface-100 px-4 py-2 text-sm font-medium text-ink hover:border-primary-200 hover:text-primary-600 transition"
+          >
+            <Sparkles className="h-4 w-4" />
+            Auto match columns
+          </button>
+        )}
+      </div>
+
+      <div className="overflow-hidden rounded-xl border border-line">
+        <div className="hidden bg-surface-200 px-4 py-3 text-xs font-medium uppercase tracking-wide text-ink/70 sm:grid sm:grid-cols-12">
+          <span className="col-span-4">Destination field</span>
+          <span className="col-span-4">Source column</span>
+          <span className="col-span-4">Sample data</span>
+        </div>
+
+        <div className="divide-y divide-line/60">
+          {targetFields.map((field) => {
+            const selectedColumnId = mapping[field.id] ?? '';
+            const selectedColumn = sourceColumns.find((column) => column.id === selectedColumnId);
+            const error = errors?.[field.id];
+
+            return (
+              <div
+                key={field.id}
+                className="flex flex-col gap-3 px-4 py-4 sm:grid sm:grid-cols-12 sm:items-center"
+              >
+                <div className="sm:col-span-4">
+                  <div className="flex items-center gap-2">
+                    <p className="font-medium text-sm text-ink">{field.label}</p>
+                    {field.required && (
+                      <span className="rounded-full bg-danger/10 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-danger">
+                        Required
+                      </span>
+                    )}
+                    {!field.required && selectedColumn && (
+                      <CheckCircle2 className="h-4 w-4 text-success" aria-hidden="true" />
+                    )}
+                  </div>
+                  {field.description && <p className="mt-1 text-xs text-muted">{field.description}</p>}
+                  {field.example && (
+                    <p className="mt-1 text-xs text-muted">
+                      Example: <span className="text-ink font-medium">{field.example}</span>
+                    </p>
+                  )}
+                </div>
+
+                <div className="sm:col-span-4">
+                  <label className="sr-only" htmlFor={`mapper-${field.id}`}>
+                    Select column for {field.label}
+                  </label>
+                  <select
+                    id={`mapper-${field.id}`}
+                    value={selectedColumnId}
+                    onChange={(event) => onChange(field.id, event.target.value || null)}
+                    className={`w-full rounded-lg border bg-white/80 px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500 ${
+                      error ? 'border-danger/60 text-danger' : 'border-line'
+                    }`}
+                  >
+                    <option value="">Select a column</option>
+                    {sourceColumns.map((column) => (
+                      <option key={column.id} value={column.id}>
+                        {column.label}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+
+                <div className="rounded-lg bg-surface-100 p-3 text-xs text-muted sm:col-span-4">
+                  {selectedColumn?.sample ? (
+                    <>
+                      <p className="font-medium text-ink">{selectedColumn.label}</p>
+                      <p className="mt-1 text-xs text-muted">Sample: {selectedColumn.sample}</p>
+                    </>
+                  ) : (
+                    <p className="text-muted">No sample available</p>
+                  )}
+                </div>
+
+                {error && (
+                  <div className="sm:col-span-12">
+                    <div className="flex items-start gap-2 rounded-lg border border-danger/40 bg-danger/10 px-3 py-2 text-xs text-danger">
+                      <AlertCircle className="mt-0.5 h-4 w-4 flex-shrink-0" />
+                      <span>{error}</span>
+                    </div>
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {hasErrors && (
+        <div className="flex items-start gap-2 rounded-lg border border-danger/30 bg-danger/10 px-3 py-2 text-sm text-danger">
+          <AlertCircle className="mt-0.5 h-4 w-4 flex-shrink-0" />
+          <span>Resolve the highlighted issues to continue.</span>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/ui/imports/ImportUploadZone.tsx
+++ b/src/components/ui/imports/ImportUploadZone.tsx
@@ -1,0 +1,171 @@
+import React, { useCallback, useRef, useState } from 'react';
+import { AlertCircle, FileSpreadsheet, Loader2, UploadCloud, X } from 'lucide-react';
+
+export interface ImportUploadZoneProps {
+  accept?: string[];
+  file?: File | null;
+  helperText?: string;
+  error?: string;
+  isUploading?: boolean;
+  maxFileSizeMb?: number;
+  onFileSelect: (file: File) => void;
+  onRemoveFile?: () => void;
+}
+
+const formatFileSize = (bytes: number) => {
+  const sizes = ['B', 'KB', 'MB', 'GB'];
+  if (bytes === 0) return '0 B';
+  const index = Math.floor(Math.log(bytes) / Math.log(1024));
+  const size = bytes / Math.pow(1024, index);
+  return `${size.toFixed(1)} ${sizes[index]}`;
+};
+
+export const ImportUploadZone: React.FC<ImportUploadZoneProps> = ({
+  accept = ['.csv', '.xlsx'],
+  error,
+  file,
+  helperText,
+  isUploading = false,
+  maxFileSizeMb = 10,
+  onFileSelect,
+  onRemoveFile,
+}) => {
+  const [isDragging, setIsDragging] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleFiles = useCallback(
+    (files: FileList | null) => {
+      if (!files || files.length === 0) return;
+      const candidate = files[0];
+      const maxBytes = maxFileSizeMb * 1024 * 1024;
+
+      if (candidate.size > maxBytes) {
+        return;
+      }
+
+      onFileSelect(candidate);
+    },
+    [maxFileSizeMb, onFileSelect]
+  );
+
+  const handleDragOver = useCallback((event: React.DragEvent<HTMLLabelElement>) => {
+    event.preventDefault();
+    setIsDragging(true);
+  }, []);
+
+  const handleDragLeave = useCallback((event: React.DragEvent<HTMLLabelElement>) => {
+    event.preventDefault();
+    setIsDragging(false);
+  }, []);
+
+  const handleDrop = useCallback(
+    (event: React.DragEvent<HTMLLabelElement>) => {
+      event.preventDefault();
+      setIsDragging(false);
+      handleFiles(event.dataTransfer.files);
+    },
+    [handleFiles]
+  );
+
+  const handleInputChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      handleFiles(event.target.files);
+    },
+    [handleFiles]
+  );
+
+  const openFileDialog = () => {
+    fileInputRef.current?.click();
+  };
+
+  const hasError = Boolean(error);
+
+  return (
+    <div className="space-y-4">
+      <label
+        htmlFor="import-upload"
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onDrop={handleDrop}
+        className={`flex flex-col items-center justify-center gap-4 px-6 py-10 border-2 border-dashed rounded-xl cursor-pointer transition-colors duration-200 bg-surface-100/50 hover:bg-surface-100 ${
+          hasError
+            ? 'border-danger/60 text-danger'
+            : isDragging
+            ? 'border-primary-500 bg-primary-100/50 text-primary-600'
+            : 'border-line/80 text-ink'
+        }`}
+      >
+        <input
+          id="import-upload"
+          ref={fileInputRef}
+          type="file"
+          accept={accept.join(',')}
+          onChange={handleInputChange}
+          className="hidden"
+        />
+
+        <div className="w-14 h-14 rounded-full bg-primary-100 flex items-center justify-center">
+          {isUploading ? (
+            <Loader2 className="h-6 w-6 animate-spin text-primary-600" />
+          ) : file ? (
+            <FileSpreadsheet className="h-6 w-6 text-primary-600" />
+          ) : (
+            <UploadCloud className="h-6 w-6 text-primary-600" />
+          )}
+        </div>
+
+        <div className="text-center space-y-1">
+          <p className="font-medium text-lg">Drag &amp; drop your file here</p>
+          <p className="text-sm text-muted">
+            {accept.join(', ')} up to {maxFileSizeMb}MB
+          </p>
+        </div>
+
+        <button
+          type="button"
+          onClick={openFileDialog}
+          className="px-4 py-2 rounded-lg bg-primary-500 text-white font-medium shadow-sm hover:bg-primary-600 transition"
+        >
+          Browse Files
+        </button>
+      </label>
+
+      {file && (
+        <div className="flex items-start justify-between rounded-lg border border-line bg-surface-100 px-4 py-3">
+          <div className="flex items-start gap-3">
+            <div className="p-2 rounded-md bg-primary-100">
+              <FileSpreadsheet className="h-5 w-5 text-primary-600" />
+            </div>
+            <div>
+              <p className="font-medium text-sm">{file.name}</p>
+              <p className="text-xs text-muted">{formatFileSize(file.size)}</p>
+            </div>
+          </div>
+
+          <div className="flex items-center gap-3">
+            {isUploading && <Loader2 className="h-4 w-4 animate-spin text-primary-500" />}
+            {onRemoveFile && (
+              <button
+                type="button"
+                onClick={onRemoveFile}
+                className="p-1 rounded-md text-muted hover:text-danger hover:bg-danger/10 transition"
+                aria-label="Remove file"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            )}
+          </div>
+        </div>
+      )}
+
+      {helperText && !hasError && <p className="text-sm text-muted">{helperText}</p>}
+
+      {hasError && (
+        <div className="flex items-start gap-2 rounded-lg border border-danger/50 bg-danger/10 px-3 py-2 text-sm text-danger">
+          <AlertCircle className="mt-0.5 h-4 w-4 flex-shrink-0" />
+          <span>{error}</span>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/config/apps.ts
+++ b/src/config/apps.ts
@@ -35,6 +35,14 @@ export const appConfigs: AppConfig[] = [
     roles: ['manager', 'owner']
   },
   {
+    id: 'imports',
+    name: 'Data Imports',
+    description: 'Upload spreadsheets and validate catalog data',
+    icon: 'FileSpreadsheet',
+    route: '/imports',
+    roles: ['manager', 'owner']
+  },
+  {
     id: 'inventory',
     name: 'Inventory',
     description: 'Stock management and tracking',


### PR DESCRIPTION
## Summary
- add a multi-step catalog import wizard covering upload, mapping, validation, and review
- build reusable import upload zone and column mapping UI components
- register the imports route/tile and log the work on the task board

## Testing
- npm run lint *(fails: existing lint errors in legacy files such as POS.tsx and StatusIndicator.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68cfe8bbb55c8326822ce76468001f03