### PR TITLE
Add shared typography helpers across core views

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -10,14 +10,14 @@
 ---
 
 ## Agent 1 — Layout
-**Scope:** Analyze and fix page layouts (grid, spacing, alignment, responsiveness).  
-**Tasks:**  
-- Review current layout structure.  
-- Fix misaligned sections, spacing, and grid inconsistencies.  
-- Improve responsiveness (mobile/tablet/desktop).  
-- Keep existing functionality untouched.  
-**Status:** TODO  
-**Log:**  
+**Scope:** Analyze and fix page layouts (grid, spacing, alignment, responsiveness).
+**Tasks:**
+- Review current layout structure.
+- Fix misaligned sections, spacing, and grid inconsistencies.
+- Improve responsiveness (mobile/tablet/desktop).
+- Keep existing functionality untouched.
+**Status:** TODO
+**Log:**
 
 ---
 
@@ -34,15 +34,15 @@
 ---
 
 ## Agent 3 — Typography
-**Scope:** Fonts, sizes, weights, and readability.  
-**Tasks:**  
-- Analyze current font stack.  
-- Apply consistent font sizes for headings, body, buttons.  
-- Fix line-height and spacing issues.  
-- Document changes here.  
-**Status:** TODO  
-**Log:**  
-
+**Scope:** Fonts, sizes, weights, and readability.
+**Tasks:**
+- Analyze current font stack.
+- Apply consistent font sizes for headings, body, buttons.
+- Fix line-height and spacing issues.
+- Document changes here.
+**Status:** DONE
+**Log:**
+- 2024-04-07: Added shared typography tokens/utilities, extended Tailwind font scale, refactored Login/Portal/BackOffice/AppShell copy to use the new helpers. `npm run lint` reports existing issues in POS, PaperShader, StatusIndicator, and themeStore outside typography scope.
 ---
 
 ## Agent 4 — Animations & Transitions

--- a/src/components/apps/BackOffice.tsx
+++ b/src/components/apps/BackOffice.tsx
@@ -28,8 +28,8 @@ export const BackOffice: React.FC = () => {
     <div className="p-6">
       <div className="max-w-5xl mx-auto space-y-8">
         <div>
-          <h1 className="text-3xl font-bold mb-2">Backoffice Settings</h1>
-          <p className="text-muted max-w-2xl">
+          <h1 className="heading-md mb-2">Backoffice Settings</h1>
+          <p className="body-md text-muted max-w-2xl">
             Configure tenant appearance, theme behaviour, and paper shader presentation. These
             controls apply instantly across the suite for every user in this tenant.
           </p>
@@ -38,8 +38,8 @@ export const BackOffice: React.FC = () => {
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
           <Card className="space-y-6">
             <div>
-              <h2 className="text-xl font-semibold">Theme Mode</h2>
-              <p className="text-muted text-sm">
+              <h2 className="heading-sm">Theme Mode</h2>
+              <p className="body-sm text-muted">
                 Choose how MAS adapts colours. Auto follows the system preference for each user.
               </p>
             </div>
@@ -57,8 +57,8 @@ export const BackOffice: React.FC = () => {
             </div>
 
             <div className="rounded-lg border border-line bg-surface-200/60 p-4">
-              <p className="text-sm text-muted">
-                Current mode: <span className="font-medium text-ink capitalize">{mode}</span>.
+              <p className="body-sm text-muted">
+                Current mode: <span className="body-sm font-medium text-ink capitalize">{mode}</span>.
               </p>
             </div>
           </Card>
@@ -66,8 +66,8 @@ export const BackOffice: React.FC = () => {
           <Card className="space-y-6">
             <div className="flex items-center justify-between gap-4">
               <div>
-                <h2 className="text-xl font-semibold">Paper Shader</h2>
-                <p className="text-muted text-sm">
+                <h2 className="heading-sm">Paper Shader</h2>
+                <p className="body-sm text-muted">
                   Toggle the tactile grain layer and fine-tune its intensity and animation speed.
                 </p>
               </div>
@@ -81,7 +81,7 @@ export const BackOffice: React.FC = () => {
 
             <div className="space-y-4">
               <label className="flex flex-col gap-2">
-                <span className="text-sm font-medium text-ink">Grain intensity</span>
+                <span className="body-sm font-medium text-ink">Grain intensity</span>
                 <input
                   type="range"
                   min={0}
@@ -93,11 +93,11 @@ export const BackOffice: React.FC = () => {
                   }
                   className="w-full accent-primary-500"
                 />
-                <span className="text-xs text-muted">{paperShader.intensity.toFixed(2)}</span>
+                <span className="body-xs text-muted">{paperShader.intensity.toFixed(2)}</span>
               </label>
 
               <label className="flex flex-col gap-2">
-                <span className="text-sm font-medium text-ink">Animation speed</span>
+                <span className="body-sm font-medium text-ink">Animation speed</span>
                 <input
                   type="range"
                   min={0}
@@ -109,12 +109,12 @@ export const BackOffice: React.FC = () => {
                   }
                   className="w-full accent-primary-500"
                 />
-                <span className="text-xs text-muted">{paperShader.animationSpeed.toFixed(1)}x</span>
+                <span className="body-xs text-muted">{paperShader.animationSpeed.toFixed(1)}x</span>
               </label>
             </div>
 
             <div>
-              <h3 className="text-sm font-medium text-ink mb-2">Apply shader to</h3>
+              <h3 className="body-sm font-medium text-ink mb-2">Apply shader to</h3>
               <div className="flex flex-wrap gap-2">
                 {paperSurfaces.map((surface) => {
                   const active = paperShader.surfaces.includes(surface);
@@ -134,8 +134,8 @@ export const BackOffice: React.FC = () => {
         </div>
 
         <Card className="space-y-4">
-          <h2 className="text-xl font-semibold">Live Preview</h2>
-          <p className="text-muted text-sm">
+          <h2 className="heading-sm">Live Preview</h2>
+          <p className="body-sm text-muted">
             Changes above update the experience instantly. Use this preview to confirm the contrast
             and motion feel right for your venue.
           </p>
@@ -143,9 +143,9 @@ export const BackOffice: React.FC = () => {
           <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
             {[1, 2, 3].map((item) => (
               <Card key={item} className="paper-card p-4 space-y-3">
-                <p className="text-sm text-muted uppercase tracking-wide">Sample Tile</p>
-                <p className="font-semibold text-lg">Surface {item}</p>
-                <p className="text-sm text-muted text-balance">
+                <p className="body-sm text-muted uppercase tracking-wide">Sample Tile</p>
+                <p className="heading-xs">Surface {item}</p>
+                <p className="body-sm text-muted text-balance">
                   The paper shader adds subtle grain and fiber texture, keeping contrast within
                   accessible ranges.
                 </p>

--- a/src/components/apps/Portal.tsx
+++ b/src/components/apps/Portal.tsx
@@ -49,8 +49,8 @@ export const Portal: React.FC = () => {
     <MotionWrapper type="page" className="p-6">
       <div className="max-w-7xl mx-auto">
         <div className="mb-8">
-          <h2 className="text-3xl font-bold mb-2">Welcome back, {user?.name}</h2>
-          <p className="text-muted">
+          <h2 className="heading-md mb-2">Welcome back, {user?.name}</h2>
+          <p className="body-md text-muted">
             {tenant?.name} • {user?.role}
           </p>
         </div>
@@ -76,15 +76,15 @@ export const Portal: React.FC = () => {
                   {app.hasNotifications && <div className="w-2 h-2 rounded-full bg-danger animate-pulse" />}
 
                   {app.isPWA && (
-                    <div className="text-xs text-muted font-medium px-2 py-1 bg-surface-200 rounded">
+                    <div className="body-xs text-muted font-medium px-2 py-1 bg-surface-200 rounded">
                       PWA
                     </div>
                   )}
                 </div>
 
-                <h3 className="font-semibold text-lg mb-2 group-hover:text-primary-600 transition-colors">{app.name}</h3>
+                <h3 className="heading-xs mb-2 group-hover:text-primary-600 transition-colors">{app.name}</h3>
 
-                <p className="text-muted text-sm leading-relaxed">{app.description}</p>
+                <p className="body-sm text-muted">{app.description}</p>
               </MotionCard>
             );
           })}
@@ -92,55 +92,55 @@ export const Portal: React.FC = () => {
 
         <div className="mt-12 grid grid-cols-1 lg:grid-cols-3 gap-6">
           <Card>
-            <h3 className="font-semibold mb-4">Today&apos;s Summary</h3>
+            <h3 className="heading-xs mb-4">Today&apos;s Summary</h3>
             <div className="space-y-3">
               <div className="flex justify-between">
-                <span className="text-muted">Orders</span>
-                <span className="font-medium">24</span>
+                <span className="body-sm text-muted">Orders</span>
+                <span className="body-sm font-medium">24</span>
               </div>
               <div className="flex justify-between">
-                <span className="text-muted">Revenue</span>
-                <span className="font-medium">$1,245.50</span>
+                <span className="body-sm text-muted">Revenue</span>
+                <span className="body-sm font-medium">$1,245.50</span>
               </div>
               <div className="flex justify-between">
-                <span className="text-muted">Avg. Order</span>
-                <span className="font-medium">$51.90</span>
+                <span className="body-sm text-muted">Avg. Order</span>
+                <span className="body-sm font-medium">$51.90</span>
               </div>
             </div>
           </Card>
 
           <Card>
-            <h3 className="font-semibold mb-4">Quick Stats</h3>
+            <h3 className="heading-xs mb-4">Quick Stats</h3>
             <div className="space-y-3">
               <div className="flex justify-between">
-                <span className="text-muted">Active Tables</span>
-                <span className="font-medium">8/12</span>
+                <span className="body-sm text-muted">Active Tables</span>
+                <span className="body-sm font-medium">8/12</span>
               </div>
               <div className="flex justify-between">
-                <span className="text-muted">Kitchen Queue</span>
-                <span className="font-medium">3 tickets</span>
+                <span className="body-sm text-muted">Kitchen Queue</span>
+                <span className="body-sm font-medium">3 tickets</span>
               </div>
               <div className="flex justify-between">
-                <span className="text-muted">Low Stock Items</span>
-                <span className="font-medium text-warning">5</span>
+                <span className="body-sm text-muted">Low Stock Items</span>
+                <span className="body-sm font-medium text-warning">5</span>
               </div>
             </div>
           </Card>
 
           <Card>
-            <h3 className="font-semibold mb-4">Recent Activity</h3>
-            <div className="space-y-3 text-sm">
+            <h3 className="heading-xs mb-4">Recent Activity</h3>
+            <div className="space-y-3">
               <div className="flex items-center gap-3">
                 <div className="w-2 h-2 rounded-full bg-success" />
-                <span className="text-muted">Order #1234 completed</span>
+                <span className="body-sm text-muted">Order #1234 completed</span>
               </div>
               <div className="flex items-center gap-3">
                 <div className="w-2 h-2 rounded-full bg-warning" />
-                <span className="text-muted">Table 5 needs attention</span>
+                <span className="body-sm text-muted">Table 5 needs attention</span>
               </div>
               <div className="flex items-center gap-3">
                 <div className="w-2 h-2 rounded-full bg-primary-500" />
-                <span className="text-muted">New reservation added</span>
+                <span className="body-sm text-muted">New reservation added</span>
               </div>
             </div>
           </Card>

--- a/src/components/auth/Login.tsx
+++ b/src/components/auth/Login.tsx
@@ -45,16 +45,16 @@ export const Login: React.FC = () => {
           {/* Logo */}
           <div className="text-center mb-8">
             <div className="w-16 h-16 bg-primary-500 rounded-lg mx-auto mb-4 flex items-center justify-center">
-              <span className="text-white font-bold text-xl">MAS</span>
+              <span className="heading-xs text-white">MAS</span>
             </div>
-            <h1 className="text-2xl font-bold text-ink">Welcome Back</h1>
-            <p className="text-muted mt-2">Sign in to your MAS account</p>
+            <h1 className="heading-sm text-ink">Welcome Back</h1>
+            <p className="body-md text-muted mt-2">Sign in to your MAS account</p>
           </div>
 
           {/* Login Form */}
           <form onSubmit={handleSubmit} className="space-y-6">
             <div>
-              <label htmlFor="email" className="block text-sm font-medium text-ink mb-2">
+              <label htmlFor="email" className="block body-sm font-medium text-ink mb-2">
                 Email Address
               </label>
               <input
@@ -69,7 +69,7 @@ export const Login: React.FC = () => {
             </div>
 
             <div>
-              <label htmlFor="password" className="block text-sm font-medium text-ink mb-2">
+              <label htmlFor="password" className="block body-sm font-medium text-ink mb-2">
                 Password
               </label>
               <div className="relative">
@@ -112,9 +112,9 @@ export const Login: React.FC = () => {
 
           {/* Demo Credentials */}
           <div className="mt-6 p-3 bg-primary-100/50 rounded-lg">
-            <p className="text-xs text-primary-700 font-medium mb-1">Demo Credentials:</p>
-            <p className="text-xs text-primary-600">Email: manager@bellavista.com</p>
-            <p className="text-xs text-primary-600">Password: password</p>
+            <p className="body-xs text-primary-700 font-medium mb-1">Demo Credentials:</p>
+            <p className="body-xs text-primary-600">Email: manager@bellavista.com</p>
+            <p className="body-xs text-primary-600">Password: password</p>
           </div>
         </div>
       </motion.div>

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -57,8 +57,8 @@ export const AppShell: React.FC = () => {
                     <Grid3x3 size={20} className="text-primary-600" />
                   </div>
                   <div>
-                    <h1 className="font-semibold text-lg">{currentApp.name}</h1>
-                    <p className="text-sm text-muted">{currentApp.description}</p>
+                    <h1 className="heading-xs">{currentApp.name}</h1>
+                    <p className="body-sm text-muted">{currentApp.description}</p>
                   </div>
                 </>
               )}
@@ -72,13 +72,13 @@ export const AppShell: React.FC = () => {
             {user && (
               <div className="flex items-center gap-2">
                 <div className="w-8 h-8 rounded-full bg-primary-500 flex items-center justify-center">
-                  <span className="text-white text-sm font-medium">
+                  <span className="body-sm font-medium text-white">
                     {user.name.charAt(0).toUpperCase()}
                   </span>
                 </div>
                 <div className="hidden sm:block">
-                  <p className="text-sm font-medium">{user.name}</p>
-                  <p className="text-xs text-muted capitalize">{user.role}</p>
+                  <p className="body-sm font-medium">{user.name}</p>
+                  <p className="body-xs text-muted capitalize">{user.role}</p>
                 </div>
               </div>
             )}

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,6 @@
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
 @import './styles/tokens.css';
+@import './styles/typography.css';
 
 @tailwind base;
 @tailwind components;
@@ -13,7 +14,7 @@
   }
 
   html {
-    font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    font-family: var(--font-family-sans);
     background-color: rgb(var(--color-bg-dust));
     color: rgb(var(--color-ink));
     scroll-behavior: smooth;

--- a/src/styles/typography.css
+++ b/src/styles/typography.css
@@ -1,0 +1,122 @@
+@layer base {
+  :root {
+    --font-family-sans: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    --font-weight-regular: 400;
+    --font-weight-medium: 500;
+    --font-weight-semibold: 600;
+    --font-weight-bold: 700;
+
+    --font-size-heading-xl: clamp(2.5rem, 1rem + 3vw, 3rem);
+    --line-height-heading-xl: 1.1;
+
+    --font-size-heading-lg: clamp(2rem, 0.95rem + 2.3vw, 2.5rem);
+    --line-height-heading-lg: 1.15;
+
+    --font-size-heading-md: clamp(1.75rem, 0.9rem + 1.8vw, 2.125rem);
+    --line-height-heading-md: 1.2;
+
+    --font-size-heading-sm: clamp(1.5rem, 1.1rem + 1vw, 1.625rem);
+    --line-height-heading-sm: 1.3;
+
+    --font-size-heading-xs: clamp(1.25rem, 1.05rem + 0.5vw, 1.375rem);
+    --line-height-heading-xs: 1.35;
+
+    --font-size-body-lg: 1.125rem;
+    --line-height-body-lg: 1.65;
+
+    --font-size-body-md: 1rem;
+    --line-height-body-md: 1.6;
+
+    --font-size-body-sm: 0.875rem;
+    --line-height-body-sm: 1.5;
+
+    --font-size-body-xs: 0.75rem;
+    --line-height-body-xs: 1.45;
+
+    --letter-spacing-heading-tight: -0.02em;
+    --letter-spacing-heading: -0.01em;
+    --letter-spacing-body: 0em;
+  }
+}
+
+@layer utilities {
+  .heading-xl {
+    font-family: var(--font-family-sans);
+    font-weight: var(--font-weight-bold);
+    font-size: var(--font-size-heading-xl);
+    line-height: var(--line-height-heading-xl);
+    letter-spacing: var(--letter-spacing-heading-tight);
+  }
+
+  .heading-lg {
+    font-family: var(--font-family-sans);
+    font-weight: var(--font-weight-bold);
+    font-size: var(--font-size-heading-lg);
+    line-height: var(--line-height-heading-lg);
+    letter-spacing: var(--letter-spacing-heading-tight);
+  }
+
+  .heading-md {
+    font-family: var(--font-family-sans);
+    font-weight: var(--font-weight-bold);
+    font-size: var(--font-size-heading-md);
+    line-height: var(--line-height-heading-md);
+    letter-spacing: var(--letter-spacing-heading);
+  }
+
+  .heading-sm {
+    font-family: var(--font-family-sans);
+    font-weight: var(--font-weight-semibold);
+    font-size: var(--font-size-heading-sm);
+    line-height: var(--line-height-heading-sm);
+    letter-spacing: var(--letter-spacing-heading);
+  }
+
+  .heading-xs {
+    font-family: var(--font-family-sans);
+    font-weight: var(--font-weight-semibold);
+    font-size: var(--font-size-heading-xs);
+    line-height: var(--line-height-heading-xs);
+    letter-spacing: var(--letter-spacing-heading);
+  }
+
+  .body-lg {
+    font-family: var(--font-family-sans);
+    font-weight: var(--font-weight-regular);
+    font-size: var(--font-size-body-lg);
+    line-height: var(--line-height-body-lg);
+    letter-spacing: var(--letter-spacing-body);
+  }
+
+  .body-md {
+    font-family: var(--font-family-sans);
+    font-weight: var(--font-weight-regular);
+    font-size: var(--font-size-body-md);
+    line-height: var(--line-height-body-md);
+    letter-spacing: var(--letter-spacing-body);
+  }
+
+  .body-sm {
+    font-family: var(--font-family-sans);
+    font-weight: var(--font-weight-regular);
+    font-size: var(--font-size-body-sm);
+    line-height: var(--line-height-body-sm);
+    letter-spacing: var(--letter-spacing-body);
+  }
+
+  .body-xs {
+    font-family: var(--font-family-sans);
+    font-weight: var(--font-weight-regular);
+    font-size: var(--font-size-body-xs);
+    line-height: var(--line-height-body-xs);
+    letter-spacing: var(--letter-spacing-body);
+  }
+
+  .body-strong {
+    font-weight: var(--font-weight-semibold);
+  }
+
+  .body-medium {
+    font-weight: var(--font-weight-medium);
+  }
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -30,6 +30,71 @@ export default {
       fontFamily: {
         sans: ['"Inter"', 'system-ui', '-apple-system', 'BlinkMacSystemFont', '"Segoe UI"', 'sans-serif'],
       },
+      fontSize: {
+        'heading-xl': [
+          'var(--font-size-heading-xl)',
+          {
+            lineHeight: 'var(--line-height-heading-xl)',
+            letterSpacing: 'var(--letter-spacing-heading-tight)',
+          },
+        ],
+        'heading-lg': [
+          'var(--font-size-heading-lg)',
+          {
+            lineHeight: 'var(--line-height-heading-lg)',
+            letterSpacing: 'var(--letter-spacing-heading-tight)',
+          },
+        ],
+        'heading-md': [
+          'var(--font-size-heading-md)',
+          {
+            lineHeight: 'var(--line-height-heading-md)',
+            letterSpacing: 'var(--letter-spacing-heading)',
+          },
+        ],
+        'heading-sm': [
+          'var(--font-size-heading-sm)',
+          {
+            lineHeight: 'var(--line-height-heading-sm)',
+            letterSpacing: 'var(--letter-spacing-heading)',
+          },
+        ],
+        'heading-xs': [
+          'var(--font-size-heading-xs)',
+          {
+            lineHeight: 'var(--line-height-heading-xs)',
+            letterSpacing: 'var(--letter-spacing-heading)',
+          },
+        ],
+        'body-lg': [
+          'var(--font-size-body-lg)',
+          {
+            lineHeight: 'var(--line-height-body-lg)',
+            letterSpacing: 'var(--letter-spacing-body)',
+          },
+        ],
+        'body-md': [
+          'var(--font-size-body-md)',
+          {
+            lineHeight: 'var(--line-height-body-md)',
+            letterSpacing: 'var(--letter-spacing-body)',
+          },
+        ],
+        'body-sm': [
+          'var(--font-size-body-sm)',
+          {
+            lineHeight: 'var(--line-height-body-sm)',
+            letterSpacing: 'var(--letter-spacing-body)',
+          },
+        ],
+        'body-xs': [
+          'var(--font-size-body-xs)',
+          {
+            lineHeight: 'var(--line-height-body-xs)',
+            letterSpacing: 'var(--letter-spacing-body)',
+          },
+        ],
+      },
       borderRadius: {
         sm: 'var(--radius-sm)',
         md: 'var(--radius-md)',


### PR DESCRIPTION
## Summary
- add shared typography variables and utility classes and load them via the global stylesheet
- extend the Tailwind font-size scale so `text-*` utilities match the new typography tokens
- apply the new heading/body helpers to Login, Portal, BackOffice, and AppShell and record completion in Agent 3 log

## Testing
- npm run lint *(fails: existing issues in POS.tsx, Portal.tsx icon typing, PaperShader.tsx escaped characters, StatusIndicator.tsx imports, and themeStore.ts unused vars)*

------
https://chatgpt.com/codex/tasks/task_e_68cfe4422d908326b59a96628f01a542