### PR TITLE
Add animated hero to portal launcher

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -10,14 +10,14 @@
 ---
 
 ## Agent 1 — Layout
-**Scope:** Analyze and fix page layouts (grid, spacing, alignment, responsiveness).  
-**Tasks:**  
-- Review current layout structure.  
-- Fix misaligned sections, spacing, and grid inconsistencies.  
-- Improve responsiveness (mobile/tablet/desktop).  
-- Keep existing functionality untouched.  
-**Status:** TODO  
-**Log:**  
+**Scope:** Analyze and fix page layouts (grid, spacing, alignment, responsiveness).
+**Tasks:**
+- Review current layout structure.
+- Fix misaligned sections, spacing, and grid inconsistencies.
+- Improve responsiveness (mobile/tablet/desktop).
+- Keep existing functionality untouched.
+**Status:** TODO
+**Log:**
 
 ---
 
@@ -28,8 +28,8 @@
 - Replace off-palette values with correct ones.  
 - Ensure Tailwind config and global tokens are updated.  
 - Verify consistency across all components.  
-**Status:** TODO  
-**Log:**  
+**Status:** TODO
+**Log:**
 
 ---
 
@@ -70,14 +70,15 @@
 ---
 
 ## Agent 6 — Hero Section
-**Scope:** Main landing section (logo, slogan, CTA).  
-**Tasks:**  
-- Center logo properly.  
-- Add slogan text with correct typography.  
-- Add primary CTA button with hover state.  
-- Document changes.  
-**Status:** TODO  
-**Log:**  
+**Scope:** Main landing section (logo, slogan, CTA).
+**Tasks:**
+- Center logo properly.
+- Add slogan text with correct typography.
+- Add primary CTA button with hover state.
+- Document changes.
+**Status:** DONE
+**Log:**
+- Implemented a motion-enabled Portal hero with brand badge, typography utilities, palette-aligned copy, animated feature bullets, and an accessible CTA wired to /pos. Wrapped the launcher content with the new PageContainer so the hero, welcome block, and app grid stack cleanly on small screens.
 
 ---
 

--- a/src/components/apps/Portal.tsx
+++ b/src/components/apps/Portal.tsx
@@ -8,6 +8,7 @@ import { useAuthStore } from '../../stores/authStore';
 import { getAvailableApps } from '../../config/apps';
 import { theme } from '../../config/theme';
 import { Card } from '@mas/ui';
+import { PortalHero, PageContainer } from './portal/PortalHero';
 
 const MotionCard = motion(Card);
 
@@ -46,16 +47,24 @@ export const Portal: React.FC = () => {
   };
 
   return (
-    <MotionWrapper type="page" className="p-6">
-      <div className="max-w-7xl mx-auto">
-        <div className="mb-8">
-          <h2 className="text-3xl font-bold mb-2">Welcome back, {user?.name}</h2>
-          <p className="text-muted">
-            {tenant?.name} • {user?.role}
-          </p>
+    <MotionWrapper type="page" className="pb-16">
+      <PageContainer className="pt-10">
+        <PortalHero />
+      </PageContainer>
+
+      <PageContainer className="mt-12 space-y-10">
+        <div className="flex flex-col items-center gap-3 text-center sm:flex-row sm:items-end sm:justify-between sm:text-left">
+          <div>
+            <h2 className="text-balance text-2xl font-semibold text-ink sm:text-3xl">
+              Welcome back, {user?.name}
+            </h2>
+            <p className="text-sm text-muted sm:text-base">
+              {tenant?.name} • {user?.role}
+            </p>
+          </div>
         </div>
 
-        <div ref={gridRef} className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+        <div ref={gridRef} className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
           {availableApps.map((app) => {
             const IconComponent = (LucideIcons as any)[app.icon] || LucideIcons.Package;
 
@@ -90,7 +99,7 @@ export const Portal: React.FC = () => {
           })}
         </div>
 
-        <div className="mt-12 grid grid-cols-1 lg:grid-cols-3 gap-6">
+        <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
           <Card>
             <h3 className="font-semibold mb-4">Today&apos;s Summary</h3>
             <div className="space-y-3">
@@ -145,7 +154,7 @@ export const Portal: React.FC = () => {
             </div>
           </Card>
         </div>
-      </div>
+      </PageContainer>
     </MotionWrapper>
   );
 };

--- a/src/components/apps/portal/PortalHero.tsx
+++ b/src/components/apps/portal/PortalHero.tsx
@@ -1,0 +1,155 @@
+import React, { useCallback, useMemo } from 'react';
+import { motion, useReducedMotion } from 'framer-motion';
+import { useNavigate } from 'react-router-dom';
+import { Button } from '@mas/ui';
+import { cn } from '@mas/utils';
+import { Grid3x3, Check } from 'lucide-react';
+import { theme } from '../../../../config/theme';
+
+const MotionButton = motion(Button);
+
+const features = [
+  {
+    title: 'Role-aware launcher',
+    description:
+      'Tiles light up with live state and badges so every role jumps into the right workflow immediately.'
+  },
+  {
+    title: 'One-tap POS entry',
+    description:
+      'Resume held tables, tabs, and orders with offline sync the moment you open the MAS POS.'
+  },
+  {
+    title: 'Shift continuity',
+    description:
+      'Hand off to kitchen, backoffice, or devices without losing the context your guests depend on.'
+  }
+] as const;
+
+export type PageContainerProps = React.HTMLAttributes<HTMLDivElement>;
+
+export const PageContainer: React.FC<PageContainerProps> = ({ className, children, ...props }) => (
+  <div className={cn('mx-auto w-full max-w-7xl px-4 sm:px-6 lg:px-8', className)} {...props}>
+    {children}
+  </div>
+);
+
+export const PortalHero: React.FC = () => {
+  const navigate = useNavigate();
+  const shouldReduceMotion = useReducedMotion();
+
+  const baseTransition = useMemo(
+    () => ({
+      duration: shouldReduceMotion ? 0 : theme.motion.routeTransition.duration,
+      ease: theme.motion.routeTransition.ease
+    }),
+    [shouldReduceMotion]
+  );
+
+  const itemTiming = useMemo(
+    () => ({
+      duration: shouldReduceMotion ? 0 : theme.motion.itemStagger.duration,
+      delayStep: shouldReduceMotion ? 0 : theme.motion.itemStagger.delay
+    }),
+    [shouldReduceMotion]
+  );
+
+  const handleCTA = useCallback(() => {
+    navigate('/pos');
+  }, [navigate]);
+
+  return (
+    <motion.section
+      initial={{ opacity: shouldReduceMotion ? 1 : 0, y: shouldReduceMotion ? 0 : 24 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={baseTransition}
+      className="relative overflow-hidden rounded-3xl border border-[#D6D6D6]/20 bg-[#24242E] px-6 py-10 text-[#D6D6D6] shadow-card sm:px-10 sm:py-14"
+    >
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(238,118,109,0.18),_transparent_55%)]"
+      />
+
+      <div className="relative z-10 flex flex-col items-center gap-10 text-center lg:flex-row lg:items-center lg:justify-between lg:text-left">
+        <div className="flex max-w-2xl flex-col items-center gap-6 text-center lg:items-start lg:text-left">
+          <motion.div
+            initial={{ opacity: shouldReduceMotion ? 1 : 0, scale: shouldReduceMotion ? 1 : 0.92 }}
+            animate={{ opacity: 1, scale: 1 }}
+            transition={baseTransition}
+            className="flex items-center justify-center"
+          >
+            <div className="flex items-center gap-3 rounded-2xl border border-[#EE766D]/30 bg-[#EE766D]/15 px-4 py-2 text-sm font-semibold text-[#EE766D] shadow-[0_10px_30px_rgba(36,36,46,0.25)]">
+              <span className="inline-flex h-10 w-10 items-center justify-center rounded-xl bg-[#EE766D]/20 text-[#EE766D]">
+                <Grid3x3 className="h-5 w-5" strokeWidth={1.6} />
+              </span>
+              <span className="uppercase tracking-wide text-xs text-[#D6D6D6]">MAS Suite</span>
+            </div>
+          </motion.div>
+
+          <motion.h1
+            initial={{ opacity: shouldReduceMotion ? 1 : 0, y: shouldReduceMotion ? 0 : 12 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={baseTransition}
+            className="text-balance text-4xl font-semibold leading-tight text-[#D6D6D6] sm:text-5xl"
+          >
+            Your command center for every service window
+          </motion.h1>
+
+          <motion.p
+            initial={{ opacity: shouldReduceMotion ? 1 : 0, y: shouldReduceMotion ? 0 : 8 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={baseTransition}
+            className="text-balance text-base text-[#D6D6D6]/80 sm:text-lg"
+          >
+            Launch straight into the MAS apps that keep guests happy and teams coordinated. Real-time status, offline resilience,
+            and context follow you wherever you go.
+          </motion.p>
+
+          <MotionButton
+            type="button"
+            variant="primary"
+            onClick={handleCTA}
+            className="!border-transparent !bg-[#EE766D] !text-[#24242E] !shadow-[0_16px_48px_rgba(238,118,109,0.35)] hover:!bg-[#f48a82] hover:!text-[#24242E] focus-visible:!ring-[#EE766D]/45 focus-visible:!ring-offset-2 focus-visible:!ring-offset-[#24242E] active:!bg-[#e55e53]"
+            whileHover={shouldReduceMotion ? undefined : { scale: 1.03 }}
+            whileTap={shouldReduceMotion ? undefined : { scale: 0.97 }}
+            transition={{
+              duration: shouldReduceMotion ? 0 : theme.motion.pressScale.duration,
+              ease: theme.motion.routeTransition.ease
+            }}
+          >
+            Open POS
+          </MotionButton>
+        </div>
+
+        <motion.ul
+          initial={{ opacity: shouldReduceMotion ? 1 : 0, y: shouldReduceMotion ? 0 : 16 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={baseTransition}
+          className="grid w-full max-w-md gap-4 text-left"
+        >
+          {features.map((feature, index) => (
+            <motion.li
+              key={feature.title}
+              initial={{ opacity: shouldReduceMotion ? 1 : 0, y: shouldReduceMotion ? 0 : 12 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{
+                duration: itemTiming.duration,
+                delay: itemTiming.delayStep * index,
+                ease: theme.motion.routeTransition.ease
+              }}
+              className="flex gap-4 rounded-2xl border border-[#D6D6D6]/15 bg-[#24242E]/40 p-4"
+            >
+              <span className="mt-1 flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-[#EE766D]/20 text-[#EE766D] ring-1 ring-inset ring-[#EE766D]/30">
+                <Check className="h-4 w-4" strokeWidth={2} />
+              </span>
+              <div className="space-y-1">
+                <h3 className="text-base font-semibold text-[#D6D6D6]">{feature.title}</h3>
+                <p className="text-sm text-[#D6D6D6]/75">{feature.description}</p>
+              </div>
+            </motion.li>
+          ))}
+        </motion.ul>
+      </div>
+    </motion.section>
+  );
+};


### PR DESCRIPTION
## Summary
- add a motion-enabled `PortalHero` section with new palette accents, typography utilities, feature bullets, and CTA routing to /pos
- wrap the portal launcher content in a shared `PageContainer` and insert the hero above the grid while keeping responsive spacing for the welcome block and cards
- log the hero update in `agents.md`

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cf87369c448326a4d8213558fca91a